### PR TITLE
Mixing building area method and space area method

### DIFF
--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.Model.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.Model.rb
@@ -48,10 +48,11 @@ class ACM179dASHRAE9012007
 
   def model_get_primary_building_type(model)
     # Maybe this is a premature optimization, but memoize the computation
-    @primary_building_types_memoized ||= Hash.new do |h, key|
-      h[key] = ACM179dASHRAE9012007.__model_get_primary_building_type(model)
-    end
-    @primary_building_types_memoized[model]
+    @primary_building_types_memoized ||= {}
+    # TODO: this will work if you pass the same model. But if you do sp.model
+    # then it changes everytime. Need to figure out a way to check if it points
+    # to the same model or not, or remove the memoization
+    @primary_building_types_memoized[model] ||= ACM179dASHRAE9012007.__model_get_primary_building_type(model)
   end
 
   # Patched to prefer the space area method above instead of just relying on

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.SpaceType.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.SpaceType.rb
@@ -5,8 +5,10 @@ class ACM179dASHRAE9012007
   # This will check the building primary type instead
   #
   # @param space_type [OpenStudio::Model::SpaceType] space type object
+  # @param extend_with_2007 [default True] whether to add anything we do not
+  #        define (ventilation, exhaust, lighting control) from ASHRAE9012007
   # @return [hash] hash of internal loads for different load types
-  def space_type_get_standards_data(space_type)
+  def space_type_get_standards_data(space_type, extend_with_2007: true)
     standards_building_type = model_get_primary_building_type(space_type.model)
 
     # populate search hash
@@ -22,6 +24,10 @@ class ACM179dASHRAE9012007
     if space_type_properties.nil?
       OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.SpaceType', "Space type properties lookup failed: #{search_criteria}.")
       space_type_properties = {}
+    end
+
+    if !extend_with_2007
+      return space_type_properties
     end
 
     # This merges the ventilation, exhaust and lighting controls

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.SpaceType.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.SpaceType.rb
@@ -24,6 +24,15 @@ class ACM179dASHRAE9012007
       space_type_properties = {}
     end
 
+    # This merges the ventilation, exhaust and lighting controls
+    data2007 = @std_2007.space_type_get_standards_data(space_type)
+    if data2007.nil?
+      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.SpaceType', "Space type properties from ASHRAE 90.1-2007 lookup failed")
+    else
+      space_type_properties = data2007.merge(space_type_properties)
+      space_type_properties['space_type_2007'] = data2007['space_type']
+    end
+
     return space_type_properties
   end
 end

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.rb
@@ -9,6 +9,10 @@ class ACM179dASHRAE9012007 < ASHRAE9012007
     @template = '179d-90.1-2007'
     @whole_building_space_type_name = 'WholeBuilding'
     load_standards_database
+
+    # This is super weird, but this is for resolving ventilation and exhaust
+    # per the space type's... and merging with the rest
+    @std_2007 = ASHRAE9012007.new
   end
 
   # Loads the openstudio standards dataset for this standard.


### PR DESCRIPTION
For anything we don't define (Ventilation, exhaust, lighting control), use a vanilla 90.1-2007 instance and merge into ours


TODO: **The tests still need to be updated to match the new behavior**