### PR TITLE
Add `model_apply_acm_hvac_availability_schedule`. 

### DIFF
--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.SpaceType.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.SpaceType.rb
@@ -26,7 +26,6 @@ class ACM179dASHRAE9012007
   #        define (ventilation, exhaust, lighting control) from ASHRAE9012007
   # @return [hash] hash of internal loads for different load types
   def space_type_get_standards_data(space_type, extend_with_2007: true, throw_if_not_found: false)
-
     space_type_properties = model_get_standards_data(space_type.model, throw_if_not_found: throw_if_not_found)
 
     if !extend_with_2007
@@ -36,7 +35,7 @@ class ACM179dASHRAE9012007
     # This merges the ventilation, exhaust and lighting controls
     data2007 = @std_2007.space_type_get_standards_data(space_type)
     if data2007.nil?
-      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.SpaceType', "Space type properties from ASHRAE 90.1-2007 lookup failed")
+      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.SpaceType', 'Space type properties from ASHRAE 90.1-2007 lookup failed')
     else
       space_type_properties = data2007.merge(space_type_properties)
       space_type_properties['space_type_2007'] = data2007['space_type']

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.SubSurface.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.SubSurface.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class ACM179dASHRAE9012007
-
   def get_exterior_fenestration_value(sub_surface, column_name)
     known_columns = [
       'Construction',
@@ -24,24 +23,24 @@ class ACM179dASHRAE9012007
       'Parent Surface',
       'Azimuth',
       'Tilt',
-      'Cardinal Direction',
+      'Cardinal Direction'
     ]
     raise "Unknown column '#{column_name}'. Available: #{known_columns}" unless known_columns.include?(column_name)
 
-    sql_query = """
+    sql_query = ''"
 SELECT Value FROM TabularDataWithStrings
   WHERE ReportName='EnvelopeSummary'
     AND ReportForString='Entire Facility'
     AND TableName='Exterior Fenestration'
-    AND RowName='#{sub_surface.nameString().upcase}'
+    AND RowName='#{sub_surface.nameString.upcase}'
     AND ColumnName='#{column_name}'
-"""
+"''
 
     val_ = sub_surface.model.sqlFile.get.execAndReturnFirstDouble(sql_query)
     raise "Query failed: #{sql_query}" if val_.empty?
+
     return val_.get
   end
-
 
   def sub_surface_get_window_property(sub_surface)
     sql_file = sub_surface.model.sqlFile
@@ -53,13 +52,12 @@ SELECT Value FROM TabularDataWithStrings
 
     # get window type
     window_type = sub_surface.subSurfaceType
-    unless ['window', 'skylight'].any? {|x| window_type.downcase.include?(x) }
+    unless ['window', 'skylight'].any? { |x| window_type.downcase.include?(x) }
       OpenStudio.logFree(OpenStudio::Error, 'openstudio.standards.SubSurface', 'SubSurface is a not a window or skylight.')
       return nil
     end
 
     sub_surface_name = sub_surface.name.to_s
-
 
     # OpenStudio SDK has only methods for querying the assembly values
     # (SubSurface::assemblySHGC / assemblyUFactor)

--- a/test/90_1_general/test_179d.rb
+++ b/test/90_1_general/test_179d.rb
@@ -293,4 +293,122 @@ class ACM179dASHRAE9012007Test < Minitest::Test
     standard.zone_hvac_component_apply_standard_controls(four_pipe_fan_coil.to_ZoneHVACComponent.get)
     refute_empty(four_pipe_fan_coil.supplyAirFanOperatingModeSchedule)
   end
+
+  def test_model_apply_acm_hvac_availability_schedule
+    model = OpenStudio::Model.exampleModel
+
+    building = model.getBuilding
+    building.setStandardsBuildingType('PrimarySchool')
+
+    _airloophvac = OpenStudio::Model::AirLoopHVAC.new(model)
+
+    _baseboardconvectiveelectric = OpenStudio::Model::ZoneHVACBaseboardConvectiveElectric.new(model)
+
+    baseboardconvectivewater_coil = OpenStudio::Model::CoilHeatingWaterBaseboard.new(model)
+    _baseboardconvectivewater = OpenStudio::Model::ZoneHVACBaseboardConvectiveWater.new(model, model.alwaysOnDiscreteSchedule, baseboardconvectivewater_coil)
+
+    _baseboardradiantconvectiveelectric = OpenStudio::Model::ZoneHVACBaseboardRadiantConvectiveElectric.new(model)
+
+    _baseboardradiantconvectivewater = OpenStudio::Model::ZoneHVACBaseboardRadiantConvectiveWater.new(model)
+
+    _coolingpanelradiantconvectivewater = OpenStudio::Model::ZoneHVACCoolingPanelRadiantConvectiveWater.new(model)
+
+    _dehumidifierdx = OpenStudio::Model::ZoneHVACDehumidifierDX.new(model)
+
+    _energyrecoveryventilator = OpenStudio::Model::ZoneHVACEnergyRecoveryVentilator.new(model)
+
+    fourPipeFan = OpenStudio::Model::FanOnOff.new(model, model.alwaysOnDiscreteSchedule)
+    fourPipeHeat = OpenStudio::Model::CoilHeatingWater.new(model, model.alwaysOnDiscreteSchedule)
+    fourPipeCool = OpenStudio::Model::CoilCoolingWater.new(model, model.alwaysOnDiscreteSchedule)
+    _fourPipeFanCoil = OpenStudio::Model::ZoneHVACFourPipeFanCoil.new(model, model.alwaysOnDiscreteSchedule,
+                                                                     fourPipeFan, fourPipeCool, fourPipeHeat)
+
+    _hightemperatureradiant = OpenStudio::Model::ZoneHVACHighTemperatureRadiant.new(model)
+
+    _idealloadsairsystem = OpenStudio::Model::ZoneHVACIdealLoadsAirSystem.new(model)
+
+    lowtemperatureradiantelectric_tempSched = OpenStudio::Model::ScheduleConstant.new(model)
+    lowtemperatureradiantelectric_tempSched.setValue(10.0)
+    _lowtemperatureradiantelectric = OpenStudio::Model::ZoneHVACLowTemperatureRadiantElectric.new(model, model.alwaysOnDiscreteSchedule, lowtemperatureradiantelectric_tempSched)
+
+    lowtempradiantconstflow_coolingHighWaterTempSched = OpenStudio::Model::ScheduleConstant.new(model)
+    lowtempradiantconstflow_coolingLowWaterTempSched = OpenStudio::Model::ScheduleConstant.new(model)
+    lowtempradiantconstflow_coolingHighControlTempSched = OpenStudio::Model::ScheduleConstant.new(model)
+    lowtempradiantconstflow_coolingLowControlTempSched = OpenStudio::Model::ScheduleConstant.new(model)
+    lowtempradiantconstflow_heatingHighWaterTempSched = OpenStudio::Model::ScheduleConstant.new(model)
+    lowtempradiantconstflow_heatingLowWaterTempSched = OpenStudio::Model::ScheduleConstant.new(model)
+    lowtempradiantconstflow_heatingHighControlTempSched = OpenStudio::Model::ScheduleConstant.new(model)
+    lowtempradiantconstflow_heatingLowControlTempSched = OpenStudio::Model::ScheduleConstant.new(model)
+
+    lowtempradiantconstflow_coolingHighWaterTempSched.setValue(15.0)
+    lowtempradiantconstflow_coolingLowWaterTempSched.setValue(10.0)
+    lowtempradiantconstflow_coolingHighControlTempSched.setValue(25.0)
+    lowtempradiantconstflow_coolingLowControlTempSched.setValue(21.0)
+    lowtempradiantconstflow_heatingHighWaterTempSched.setValue(50.0)
+    lowtempradiantconstflow_heatingLowWaterTempSched.setValue(30.0)
+    lowtempradiantconstflow_heatingHighControlTempSched.setValue(20.0)
+    lowtempradiantconstflow_heatingLowControlTempSched.setValue(17.0)
+    lowtempradiantconstflow_heat_coil = OpenStudio::Model::CoilHeatingLowTempRadiantConstFlow.new(model, lowtempradiantconstflow_heatingHighWaterTempSched, lowtempradiantconstflow_heatingLowWaterTempSched, lowtempradiantconstflow_heatingHighControlTempSched, lowtempradiantconstflow_heatingLowControlTempSched)
+    lowtempradiantconstflow_cool_coil = OpenStudio::Model::CoilCoolingLowTempRadiantConstFlow.new(model, lowtempradiantconstflow_coolingHighWaterTempSched, lowtempradiantconstflow_coolingLowWaterTempSched, lowtempradiantconstflow_coolingHighControlTempSched, lowtempradiantconstflow_coolingLowControlTempSched)
+    _lowtempradiantconstflow = OpenStudio::Model::ZoneHVACLowTempRadiantConstFlow.new(model, model.alwaysOnDiscreteSchedule, lowtempradiantconstflow_heat_coil, lowtempradiantconstflow_cool_coil, 200.0)
+
+    _lowtempradiantvarflow = OpenStudio::Model::ZoneHVACLowTempRadiantVarFlow.new(model)
+
+    ptac_htg_coil = OpenStudio::Model::CoilHeatingElectric.new(model)
+    ptac_clg_coil = OpenStudio::Model::CoilCoolingDXSingleSpeed.new(model)
+    ptac_fan = OpenStudio::Model::FanOnOff.new(model, model.alwaysOnDiscreteSchedule)
+    _ptac = OpenStudio::Model::ZoneHVACPackagedTerminalAirConditioner.new(model, model.alwaysOffDiscreteSchedule, ptac_fan, ptac_htg_coil, ptac_clg_coil)
+
+    pthp_htg_coil = OpenStudio::Model::CoilHeatingDXSingleSpeed.new(model)
+    pthp_clg_coil = OpenStudio::Model::CoilCoolingDXSingleSpeed.new(model)
+    pthp_fan = OpenStudio::Model::FanOnOff.new(model, model.alwaysOnDiscreteSchedule)
+    pthp_supp_htg_coil = OpenStudio::Model::CoilHeatingElectric.new(model)
+    _pthp = OpenStudio::Model::ZoneHVACPackagedTerminalHeatPump.new(model, model.alwaysOffDiscreteSchedule, pthp_fan, pthp_htg_coil, pthp_clg_coil, pthp_supp_htg_coil)
+
+    unitheater_fan = OpenStudio::Model::FanConstantVolume.new(model, model.alwaysOnDiscreteSchedule)
+    unitheater_coil = OpenStudio::Model::CoilHeatingElectric.new(model, model.alwaysOnDiscreteSchedule)
+    _unitheater = OpenStudio::Model::ZoneHVACUnitHeater.new(model, model.alwaysOnDiscreteSchedule, unitheater_fan, unitheater_coil)
+
+    _unitventilator = OpenStudio::Model::ZoneHVACUnitVentilator.new(model)
+
+    wtahp_fan = OpenStudio::Model::FanOnOff.new(model)
+    wtahp_DXHC = OpenStudio::Model::CoilHeatingWaterToAirHeatPumpEquationFit.new(model)
+    wtahp_DXCC = OpenStudio::Model::CoilCoolingWaterToAirHeatPumpEquationFit.new(model)
+    wtahp_supplementalHC = OpenStudio::Model::CoilHeatingElectric.new(model, model.alwaysOnDiscreteSchedule)
+    _wtahp = OpenStudio::Model::ZoneHVACWaterToAirHeatPump.new(model, model.alwaysOnDiscreteSchedule, wtahp_fan, wtahp_DXHC, wtahp_DXCC, wtahp_supplementalHC)
+
+    _airloophvacunitarysystem = OpenStudio::Model::AirLoopHVACUnitarySystem.new(model)
+
+    avail_sch = OpenStudio::Model::ScheduleConstant.new(model)
+
+    ACM179dASHRAE9012007::HVAC_AVAILABILITY_SCHEDULE_MAP.each do |hvac_type, methods|
+      objects = model.send("get#{hvac_type}s")
+      refute_empty objects, "Missing object of type #{hvac_type} in model"
+      obj = objects.first
+      methods.each do |getter, setter|
+        assert obj.respond_to?(getter)
+        assert obj.respond_to?(setter)
+        assert obj.send(setter, avail_sch)
+      end
+    end
+
+    assert standard.model_apply_acm_hvac_availability_schedule(model)
+
+    ACM179dASHRAE9012007::HVAC_AVAILABILITY_SCHEDULE_MAP.each do |hvac_type, methods|
+      objects = model.send("get#{hvac_type}s")
+      refute_empty objects, "Missing object of type #{hvac_type} in model"
+      objects.each do |obj|
+        methods.each do |getter, _|
+          new_avail_sch = obj.send(getter)
+          # if new_avail_sch.class.name.include?('OptionalSchedule')
+          if new_avail_sch.respond_to?(:get)
+            new_avail_sch = new_avail_sch.get
+          end
+          refute_equal(avail_sch, new_avail_sch, "#{obj.briefDescription}: #{getter}")
+          assert_equal('SchoolPrimary_HVAC_Sch', new_avail_sch.nameString, "#{obj.briefDescription}: #{getter}")
+        end
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
**This is currently unused** but will very likely be required soon.

I'm basically porting over the changes from https://github.com/NREL/openstudio-bem-to-surrogate-gem/pull/30

When overriding `model_add_prm_baseline_system`, we could pass `hvac_op_sch` in all of the methods that are in lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb **that actually have such a param**.

model_add_unitheater for eg has it.

https://github.com/jmarrec/openstudio-standards/blob/f37d676ef9ccf656e5dcb37000374b848cf2a340/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb#L4023-L4025

model_add_ptac does not

https://github.com/jmarrec/openstudio-standards/blob/f37d676ef9ccf656e5dcb37000374b848cf2a340/lib/openstudio-standards/prototypes/common/objects/Prototype.hvac_systems.rb#L3812-L3818


@brianlball 