### PR TITLE
overriding 90.1-2007 HVAC efficiencies based on the latest 90.1-2007

### DIFF
--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.CoilHeatingDXMultiSpeed.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.CoilHeatingDXMultiSpeed.rb
@@ -1,4 +1,4 @@
-class Standard
+class ACM179dASHRAE9012007
   # @!group CoilHeatingDXMultiSpeed
 
   # Applies the standard efficiency ratings and typical performance curves to this object.

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.CoilHeatingDXMultiSpeed.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.CoilHeatingDXMultiSpeed.rb
@@ -1,0 +1,189 @@
+class Standard
+  # @!group CoilHeatingDXMultiSpeed
+
+  # Applies the standard efficiency ratings and typical performance curves to this object.
+  #
+  # @param coil_heating_dx_multi_speed [OpenStudio::Model::CoilHeatingDXMultiSpeed] coil heating dx multi speed object
+  # @return [Bool] returns true if successful, false if not
+  def coil_heating_dx_multi_speed_apply_efficiency_and_curves(coil_heating_dx_multi_speed, sql_db_vars_map)
+    successfully_set_all_properties = true
+
+    # Define the criteria to find the unitary properties
+    # in the hvac standards data set.
+    search_criteria = {}
+    search_criteria['template'] = template
+
+    # Determine supplemental heating type if unitary
+    heat_pump = false
+    suppl_heating_type = nil
+    if coil_heating_dx_multi_speed.airLoopHVAC.empty?
+      if coil_heating_dx_multi_speed.containingHVACComponent.is_initialized
+        containing_comp = coil_heating_dx_multi_speed.containingHVACComponent.get
+        if containing_comp.to_AirLoopHVACUnitaryHeatPumpAirToAirMultiSpeed.is_initialized
+          heat_pump = true
+          htg_coil = containing_comp.to_AirLoopHVACUnitaryHeatPumpAirToAirMultiSpeed.get.supplementalHeatingCoil
+          suppl_heating_type = if htg_coil.to_CoilHeatingElectric.is_initialized
+                                 'Electric Resistance or None'
+                               else
+                                 'All Other'
+                               end
+        end
+        # @todo Add other unitary systems
+      end
+    end
+
+    # @todo Standards - add split system vs single package to model
+    # For now, assume single package
+    subcategory = 'Single Package'
+    search_criteria['subcategory'] = subcategory
+
+    # Get the coil capacity
+    clg_capacity = nil
+    if heat_pump == true
+      containing_comp = coil_heating_dx_multi_speed.containingHVACComponent.get
+      heat_pump_comp = containing_comp.to_AirLoopHVACUnitaryHeatPumpAirToAirMultiSpeed.get
+      ccoil = heat_pump_comp.coolingCoil
+      dxcoil = ccoil.to_CoilCoolingDXMultiSpeed.get
+      dxcoil_name = dxcoil.name.to_s
+      if sql_db_vars_map
+        if sql_db_vars_map[dxcoil_name]
+          dxcoil.setName(sql_db_vars_map[dxcoil_name])
+        end
+      end
+      clg_stages = dxcoil.stages
+      if clg_stages.last.grossRatedTotalCoolingCapacity.is_initialized
+        clg_capacity = clg_stages.last.grossRatedTotalCoolingCapacity.get
+      elsif dxcoil.autosizedSpeed4GrossRatedTotalCoolingCapacity.is_initialized
+        clg_capacity = dxcoil.autosizedSpeed4GrossRatedTotalCoolingCapacity.get
+      else
+        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingDXMultiSpeed', "For #{coil_heating_dx_multi_speed.name} capacity is not available, cannot apply efficiency standard.")
+        successfully_set_all_properties = false
+        return successfully_set_all_properties
+      end
+      dxcoil.setName(dxcoil_name)
+    end
+
+    # Convert capacity to Btu/hr
+    capacity_btu_per_hr = OpenStudio.convert(clg_capacity, 'W', 'Btu/hr').get
+    capacity_kbtu_per_hr = OpenStudio.convert(clg_capacity, 'W', 'kBtu/hr').get
+
+    # Lookup efficiencies depending on whether it is a unitary AC or a heat pump
+    hp_props = model_find_object(standards_data['heat_pumps'], search_criteria, capacity_btu_per_hr, Date.today)
+
+    # Check to make sure properties were found
+    if hp_props.nil?
+      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingDXMultipeed', "For #{coil_heating_dx_multi_speed.name}, cannot find efficiency info using #{search_criteria}, cannot apply efficiency standard.")
+      successfully_set_all_properties = false
+      return successfully_set_all_properties
+    end
+
+    # Make the HEAT-CAP-FT curve
+    htg_stages = stages
+    heat_cap_ft = model_add_curve(model, hp_props['heat_cap_ft'], standards)
+    if heat_cap_ft
+      htg_stages.each do |istage|
+        istage.setHeatingCapacityFunctionofTemperatureCurve(heat_cap_ft)
+      end
+    else
+      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingDXMultiSpeed', "For #{coil_heating_dx_multi_speed.name}, cannot find heat_cap_ft curve, will not be set.")
+      successfully_set_all_properties = false
+    end
+
+    # Make the HEAT-CAP-FFLOW curve
+    heat_cap_fflow = model_add_curve(model, hp_props['heat_cap_fflow'], standards)
+    if heat_cap_fflow
+      htg_stages.each do |istage|
+        istage.setHeatingCapacityFunctionofFlowFractionCurve(heat_cap_fflow)
+      end
+    else
+      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingDXMultiSpeed', "For #{coil_heating_dx_multi_speed.name}, cannot find heat_cap_fflow curve, will not be set.")
+      successfully_set_all_properties = false
+    end
+
+    # Make the HEAT-EIR-FT curve
+    heat_eir_ft = model_add_curve(model, hp_props['heat_eir_ft'], standards)
+    if heat_eir_ft
+      htg_stages.each do |istage|
+        istage.setEnergyInputRatioFunctionofTemperatureCurve(heat_eir_ft)
+      end
+    else
+      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingDXMultiSpeed', "For #{coil_heating_dx_multi_speed.name}, cannot find heat_eir_ft curve, will not be set.")
+      successfully_set_all_properties = false
+    end
+
+    # Make the HEAT-EIR-FFLOW curve
+    heat_eir_fflow = model_add_curve(model, hp_props['heat_eir_fflow'], standards)
+    if heat_eir_fflow
+      htg_stages.each do |istage|
+        istage.setEnergyInputRatioFunctionofFlowFractionCurve(heat_eir_fflow)
+      end
+    else
+      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingDXMultiSpeed', "For #{coil_heating_dx_multi_speed.name}, cannot find heat_eir_fflow curve, will not be set.")
+      successfully_set_all_properties = false
+    end
+
+    # Make the HEAT-PLF-FPLR curve
+    heat_plf_fplr = model_add_curve(model, hp_props['heat_plf_fplr'], standards)
+    if heat_plf_fplr
+      htg_stages.each do |istage|
+        istage.setPartLoadFractionCorrelationCurve(heat_plf_fplr)
+      end
+    else
+      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingDXMultiSpeed', "For #{coil_heating_dx_multi_speed.name}, cannot find heat_plf_fplr curve, will not be set.")
+      successfully_set_all_properties = false
+    end
+
+    htg_capacity = nil
+    flow_rate4 = nil
+    htg_stages = coil_heating_dx_multi_speed.stages
+    if htg_stages.last.grossRatedHeatingCapacity.is_initialized
+      htg_capacity = htg_stages.last.grossRatedHeatingCapacity.get
+    elsif coil_heating_dx_multi_speed.autosizedSpeed4GrossRatedHeatingCapacity.is_initialized
+      htg_capacity = coil_heating_dx_multi_speed.autosizedSpeed4GrossRatedHeatingCapacity.get
+    else
+      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingDXMultiSpeed', "For #{coil_heating_dx_multi_speed.name} capacity is not available, cannot apply efficiency standard.")
+      successfully_set_all_properties = false
+      return successfully_set_all_properties
+    end
+    if htg_stages.last.ratedAirFlowRate.is_initialized
+      flow_rate4 = htg_stages.last.ratedAirFlowRate.get
+    elsif coil_heating_dx_multi_speed.autosizedSpeed4RatedAirFlowRate.is_initialized
+      flow_rate4 = coil_heating_dx_multi_speed.autosizedSpeed4RatedAirFlowRate.get
+    else
+      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingDXMultiSpeed', "For #{coil_heating_dx_multi_speed.name} capacity is not available, cannot apply efficiency standard.")
+      successfully_set_all_properties = false
+      return successfully_set_all_properties
+    end
+
+    # Convert capacity to Btu/hr
+    capacity_btu_per_hr = OpenStudio.convert(htg_capacity, 'W', 'Btu/hr').get
+    capacity_kbtu_per_hr = OpenStudio.convert(htg_capacity, 'W', 'kBtu/hr').get
+
+    # Get the minimum efficiency standards
+    cop = nil
+
+    # If specified as SEER
+    unless hp_props['minimum_seasonal_energy_efficiency_ratio'].nil?
+      min_seer = hp_props['minimum_seasonal_energy_efficiency_ratio']
+      cop = seer_to_cop_cooling_no_fan(min_seer)
+      coil_heating_dx_multi_speed.setName("#{coil_heating_dx_multi_speed.name} #{capacity_kbtu_per_hr.round}kBtu/hr #{min_seer}SEER")
+      OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.CoilHeatingDXMultiSpeed', "For #{template}: #{coil_heating_dx_multi_speed.name}: #{suppl_heating_type} #{subcategory} Capacity = #{capacity_kbtu_per_hr.round}kBtu/hr; SEER = #{min_seer}")
+    end
+
+    # If specified as EER
+    unless hp_props['minimum_energy_efficiency_ratio'].nil?
+      min_eer = hp_props['minimum_energy_efficiency_ratio']
+      cop = eer_to_cop(min_eer)
+      coil_heating_dx_multi_speed.setName("#{coil_heating_dx_multi_speed.name} #{capacity_kbtu_per_hr.round}kBtu/hr #{min_eer}EER")
+      OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.CoilHeatingDXMultiSpeed', "For #{template}: #{coil_heating_dx_multi_speed.name}:  #{suppl_heating_type} #{subcategory} Capacity = #{capacity_kbtu_per_hr.round}kBtu/hr; EER = #{min_eer}")
+    end
+
+    # Set the efficiency values
+    return false if cop.nil?
+
+    htg_stages.each do |istage|
+      istage.setGrossRatedHeatingCOP(cop)
+    end
+    return true
+  end
+end

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.CoilHeatingDXSingleSpeed.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.CoilHeatingDXSingleSpeed.rb
@@ -1,0 +1,268 @@
+class Standard
+  # @!group CoilHeatingDXSingleSpeed
+
+  include CoilDX
+
+  # Finds capacity in W.  This is the cooling capacity of the paired DX cooling coil.
+  #
+  # @param coil_heating_dx_single_speed [OpenStudio::Model::CoilHeatingDXSingleSpeed] coil heating dx single speed object
+  # @param necb_ref_hp [Bool] for compatability with NECB ruleset only.
+  # @return [Double] capacity in W to be used for find object
+  def coil_heating_dx_single_speed_find_capacity(coil_heating_dx_single_speed, necb_ref_hp = false)
+    capacity_w = nil
+
+    # Get the paired cooling coil
+    clg_coil = nil
+
+    # Unitary and zone equipment
+    if coil_heating_dx_single_speed.airLoopHVAC.empty?
+      if coil_heating_dx_single_speed.containingHVACComponent.is_initialized
+        containing_comp = coil_heating_dx_single_speed.containingHVACComponent.get
+        if containing_comp.to_AirLoopHVACUnitaryHeatPumpAirToAir.is_initialized
+          clg_coil = containing_comp.to_AirLoopHVACUnitaryHeatPumpAirToAir.get.coolingCoil
+        elsif containing_comp.to_AirLoopHVACUnitarySystem.is_initialized
+          unitary = containing_comp.to_AirLoopHVACUnitarySystem.get
+          if unitary.coolingCoil.is_initialized
+            clg_coil = unitary.coolingCoil.get
+          end
+        end
+        # @todo Add other unitary systems
+      elsif coil_heating_dx_single_speed.containingZoneHVACComponent.is_initialized
+        containing_comp = coil_heating_dx_single_speed.containingZoneHVACComponent.get
+        # PTHP
+        if containing_comp.to_ZoneHVACPackagedTerminalHeatPump.is_initialized
+          pthp = containing_comp.to_ZoneHVACPackagedTerminalHeatPump.get
+          clg_coil = containing_comp.to_ZoneHVACPackagedTerminalHeatPump.get.coolingCoil
+        end
+      end
+    end
+
+    # On AirLoop directly
+    if coil_heating_dx_single_speed.airLoopHVAC.is_initialized
+      air_loop = coil_heating_dx_single_speed.airLoopHVAC.get
+      # Check for the presence of any other type of cooling coil
+      clg_types = ['OS:Coil:Cooling:DX:SingleSpeed',
+                   'OS:Coil:Cooling:DX:TwoSpeed',
+                   'OS:Coil:Cooling:DX:MultiSpeed']
+      clg_types.each do |ct|
+        coils = air_loop.supplyComponents(ct.to_IddObjectType)
+        next if coils.empty?
+
+        clg_coil = coils[0]
+        break # Stop on first DX cooling coil found
+      end
+    end
+
+    # If no paired cooling coil was found,
+    # throw an error and fall back to the heating capacity
+    # of the DX heating coil
+    if clg_coil.nil?
+      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingDXSingleSpeed', "For #{coil_heating_dx_single_speed.name}, the paired DX cooling coil could not be found to determine capacity. Efficiency will incorrectly be based on DX coil's heating capacity.")
+      if coil_heating_dx_single_speed.ratedTotalHeatingCapacity.is_initialized
+        capacity_w = coil_heating_dx_single_speed.ratedTotalHeatingCapacity.get
+      elsif coil_heating_dx_single_speed.autosizedRatedTotalHeatingCapacity.is_initialized
+        capacity_w = coil_heating_dx_single_speed.autosizedRatedTotalHeatingCapacity.get
+      else
+        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingDXSingleSpeed', "For #{coil_heating_dx_single_speed.name} capacity is not available, cannot apply efficiency standard to paired DX heating coil.")
+        return 0.0
+      end
+      return capacity_w
+    end
+
+    # If a coil was found, cast to the correct type
+    if clg_coil.to_CoilCoolingDXSingleSpeed.is_initialized
+      clg_coil = clg_coil.to_CoilCoolingDXSingleSpeed.get
+      capacity_w = coil_cooling_dx_single_speed_find_capacity(clg_coil)
+    elsif clg_coil.to_CoilCoolingDXTwoSpeed.is_initialized
+      clg_coil = clg_coil.to_CoilCoolingDXTwoSpeed.get
+      capacity_w = coil_cooling_dx_two_speed_find_capacity(clg_coil)
+    elsif clg_coil.to_CoilCoolingDXMultiSpeed.is_initialized
+      clg_coil = clg_coil.to_CoilCoolingDXMultiSpeed.get
+      capacity_w = coil_cooling_dx_multi_speed_find_capacity(clg_coil)
+    end
+
+    # If it's a PTAC or PTHP System, we need to divide the capacity by the potential zone multiplier
+    # because the COP is dependent on capacity, and the capacity should be the capacity of a single zone, not all the zones
+    if ['PTAC', 'PTHP'].include?(coil_dx_subcategory(coil_heating_dx_single_speed))
+      mult = 1
+      comp = coil_heating_dx_single_speed.containingZoneHVACComponent
+      if comp.is_initialized
+        if comp.get.thermalZone.is_initialized
+          mult = comp.get.thermalZone.get.multiplier
+          if mult > 1
+            total_cap = capacity_w
+            capacity_w /= mult
+            OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.CoilHeatingDXSingleSpeed', "For #{coil_heating_dx_single_speed.name}, total capacity of #{OpenStudio.convert(total_cap, 'W', 'kBtu/hr').get.round(2)}kBTU/hr was divided by the zone multiplier of #{mult} to give #{capacity_kbtu_per_hr = OpenStudio.convert(capacity_w, 'W', 'kBtu/hr').get.round(2)}kBTU/hr.")
+          end
+        end
+      end
+    end
+
+    return capacity_w
+  end
+
+  # Finds lookup object in standards and return efficiency
+  #
+  # @param coil_heating_dx_single_speed [OpenStudio::Model::CoilHeatingDXSingleSpeed] coil heating dx single speed object
+  # @param rename [Bool] if true, object will be renamed to include capacity and efficiency level
+  # @param necb_ref_hp [Bool] for compatability with NECB ruleset only.
+  # @return [Double] full load efficiency (COP)
+  def coil_heating_dx_single_speed_standard_minimum_cop(coil_heating_dx_single_speed, rename = false, necb_ref_hp = false)
+    # find ac properties
+    search_criteria = coil_dx_find_search_criteria(coil_heating_dx_single_speed, necb_ref_hp)
+    sub_category = search_criteria['subcategory']
+    suppl_heating_type = search_criteria['heating_type']
+    capacity_w = coil_heating_dx_single_speed_find_capacity(coil_heating_dx_single_speed, necb_ref_hp)
+    capacity_btu_per_hr = OpenStudio.convert(capacity_w, 'W', 'Btu/hr').get
+    capacity_kbtu_per_hr = OpenStudio.convert(capacity_w, 'W', 'kBtu/hr').get
+
+    # Get the minimum efficiency standards
+    cop = nil
+
+    # find object
+    ac_props = model_find_object(standards_data['heat_pumps_heating'], search_criteria, capacity_btu_per_hr, Date.today)
+
+    # Check to make sure properties were found
+    if ac_props.nil?
+      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingDXSingleSpeed', "For #{coil_heating_dx_single_speed.name}, cannot find efficiency info using #{search_criteria}, cannot apply efficiency standard.")
+      return cop # value of nil
+    end
+
+    # If PTHP, use equations
+    if sub_category == 'PTHP'
+      pthp_cop_coeff_1 = ac_props['pthp_cop_coefficient_1']
+      pthp_cop_coeff_2 = ac_props['pthp_cop_coefficient_2']
+      # TABLE 6.8.1D
+      # COP = pthp_cop_coeff_1 - (pthp_cop_coeff_2 * Cap / 1000)
+      # Note c: Cap means the rated cooling capacity of the product in Btu/h.
+      # If the unit's capacity is less than 7000 Btu/h, use 7000 Btu/h in the calculation.
+      # If the unit's capacity is greater than 15,000 Btu/h, use 15,000 Btu/h in the calculation.
+      capacity_btu_per_hr = 7000 if capacity_btu_per_hr < 7000
+      capacity_btu_per_hr = 15_000 if capacity_btu_per_hr > 15_000
+      min_coph = pthp_cop_coeff_1 - (pthp_cop_coeff_2 * capacity_btu_per_hr / 1000.0)
+      cop = cop_heating_to_cop_heating_no_fan(min_coph, OpenStudio.convert(capacity_kbtu_per_hr, 'kBtu/hr', 'W').get)
+      new_comp_name = "#{coil_heating_dx_single_speed.name} #{capacity_kbtu_per_hr.round} Clg kBtu/hr #{min_coph.round(1)}COPH"
+      OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.CoilHeatingDXSingleSpeed', "For #{coil_heating_dx_single_speed.name}: #{sub_category} Cooling Capacity = #{capacity_kbtu_per_hr.round}kBtu/hr; COPH = #{min_coph.round(2)}")
+    end
+
+    # If specified as HSPF
+    unless ac_props['minimum_heating_seasonal_performance_factor'].nil?
+      min_hspf = ac_props['minimum_heating_seasonal_performance_factor']
+      cop = hspf_to_cop_heating_no_fan(min_hspf)
+      new_comp_name = "#{coil_heating_dx_single_speed.name} #{capacity_kbtu_per_hr.round} Clg kBtu/hr #{min_hspf.round(1)}HSPF"
+      OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.CoilHeatingDXSingleSpeed', "For #{template}: #{coil_heating_dx_single_speed.name}: #{suppl_heating_type} #{sub_category} Cooling Capacity = #{capacity_kbtu_per_hr.round}kBtu/hr; HSPF = #{min_hspf}")
+    end
+
+    # If specified as COPH
+    unless ac_props['minimum_coefficient_of_performance_heating'].nil?
+      min_coph = ac_props['minimum_coefficient_of_performance_heating']
+      cop = cop_heating_to_cop_heating_no_fan(min_coph, OpenStudio.convert(capacity_kbtu_per_hr, 'kBtu/hr', 'W').get)
+      new_comp_name = "#{coil_heating_dx_single_speed.name} #{capacity_kbtu_per_hr.round} Clg kBtu/hr #{min_coph.round(1)}COPH"
+      OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.CoilHeatingDXSingleSpeed', "For #{template}: #{coil_heating_dx_single_speed.name}: #{suppl_heating_type} #{sub_category} Cooling Capacity = #{capacity_kbtu_per_hr.round}kBtu/hr; COPH = #{min_coph}")
+    end
+
+    # If specified as EER
+    unless ac_props['minimum_energy_efficiency_ratio'].nil?
+      min_eer = ac_props['minimum_energy_efficiency_ratio']
+      cop = eer_to_cop(min_eer)
+      new_comp_name = "#{coil_heating_dx_single_speed.name} #{capacity_kbtu_per_hr.round} Clg kBtu/hr #{min_eer.round(1)}EER"
+      OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.CoilHeatingDXSingleSpeed', "For #{template}: #{coil_heating_dx_single_speed.name}:  #{suppl_heating_type} #{sub_category} Cooling Capacity = #{capacity_kbtu_per_hr.round}kBtu/hr; EER = #{min_eer}")
+    end
+
+    # Rename
+    if rename
+      coil_heating_dx_single_speed.setName(new_comp_name)
+    end
+
+    return cop
+  end
+
+  # Applies the standard efficiency ratings and typical performance curves to this object.
+  #
+  # @param coil_heating_dx_single_speed [OpenStudio::Model::CoilHeatingDXSingleSpeed] coil heating dx single speed object
+  # @param sql_db_vars_map [Hash] hash map
+  # @param necb_ref_hp [Bool] for compatability with NECB ruleset only.
+  # @return [Hash] hash of coil objects
+  def coil_heating_dx_single_speed_apply_efficiency_and_curves(coil_heating_dx_single_speed, sql_db_vars_map, necb_ref_hp = false)
+    successfully_set_all_properties = true
+
+    # Get the search criteria
+    search_criteria = coil_dx_find_search_criteria(coil_heating_dx_single_speed, necb_ref_hp)
+
+    # Get the capacity
+    capacity_w = coil_heating_dx_single_speed_find_capacity(coil_heating_dx_single_speed, necb_ref_hp)
+    capacity_btu_per_hr = OpenStudio.convert(capacity_w, 'W', 'Btu/hr').get
+    capacity_kbtu_per_hr = OpenStudio.convert(capacity_w, 'W', 'kBtu/hr').get
+
+    # Lookup efficiencies
+    ac_props = model_find_object(standards_data['heat_pumps_heating'], search_criteria, capacity_btu_per_hr, Date.today)
+
+    # Check to make sure properties were found
+    if ac_props.nil?
+      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingDXSingleSpeed', "For #{coil_heating_dx_single_speed.name}, cannot find efficiency info using #{search_criteria}, cannot apply efficiency standard.")
+      successfully_set_all_properties = false
+      return sql_db_vars_map
+    end
+
+    # Make the HEAT-CAP-FT curve
+    heat_cap_ft = model_add_curve(coil_heating_dx_single_speed.model, ac_props['heat_cap_ft'])
+    if heat_cap_ft
+      coil_heating_dx_single_speed.setTotalHeatingCapacityFunctionofTemperatureCurve(heat_cap_ft)
+    else
+      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingDXSingleSpeed', "For #{coil_heating_dx_single_speed.name}, cannot find heat_cap_ft curve, will not be set.")
+      successfully_set_all_properties = false
+    end
+
+    # Make the HEAT-CAP-FFLOW curve
+    heat_cap_fflow = model_add_curve(coil_heating_dx_single_speed.model, ac_props['heat_cap_fflow'])
+    if heat_cap_fflow
+      coil_heating_dx_single_speed.setTotalHeatingCapacityFunctionofFlowFractionCurve(heat_cap_fflow)
+    else
+      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingDXSingleSpeed', "For #{coil_heating_dx_single_speed.name}, cannot find heat_cap_fflow curve, will not be set.")
+      successfully_set_all_properties = false
+    end
+
+    # Make the HEAT-EIR-FT curve
+    heat_eir_ft = model_add_curve(coil_heating_dx_single_speed.model, ac_props['heat_eir_ft'])
+    if heat_eir_ft
+      coil_heating_dx_single_speed.setEnergyInputRatioFunctionofTemperatureCurve(heat_eir_ft)
+    else
+      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingDXSingleSpeed', "For #{coil_heating_dx_single_speed.name}, cannot find heat_eir_ft curve, will not be set.")
+      successfully_set_all_properties = false
+    end
+
+    # Make the HEAT-EIR-FFLOW curve
+    heat_eir_fflow = model_add_curve(coil_heating_dx_single_speed.model, ac_props['heat_eir_fflow'])
+    if heat_eir_fflow
+      coil_heating_dx_single_speed.setEnergyInputRatioFunctionofFlowFractionCurve(heat_eir_fflow)
+    else
+      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingDXSingleSpeed', "For #{coil_heating_dx_single_speed.name}, cannot find heat_eir_fflow curve, will not be set.")
+      successfully_set_all_properties = false
+    end
+
+    # Make the HEAT-PLF-FPLR curve
+    heat_plf_fplr = model_add_curve(coil_heating_dx_single_speed.model, ac_props['heat_plf_fplr'])
+    if heat_plf_fplr
+      coil_heating_dx_single_speed.setPartLoadFractionCorrelationCurve(heat_plf_fplr)
+    else
+      OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.CoilHeatingDXSingleSpeed', "For #{coil_heating_dx_single_speed.name}, cannot find heat_plf_fplr curve, will not be set.")
+      successfully_set_all_properties = false
+    end
+
+    # Preserve the original name
+    orig_name = coil_heating_dx_single_speed.name.to_s
+
+    # Find the minimum COP and rename with efficiency rating
+    cop = coil_heating_dx_single_speed_standard_minimum_cop(coil_heating_dx_single_speed, true, necb_ref_hp)
+
+    # Map the original name to the new name
+    sql_db_vars_map[coil_heating_dx_single_speed.name.to_s] = orig_name
+
+    # Set the efficiency values
+    unless cop.nil?
+      coil_heating_dx_single_speed.setRatedCOP(cop)
+    end
+
+    return sql_db_vars_map
+  end
+end

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.CoilHeatingDXSingleSpeed.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.CoilHeatingDXSingleSpeed.rb
@@ -1,4 +1,4 @@
-class Standard
+class ACM179dASHRAE9012007
   # @!group CoilHeatingDXSingleSpeed
 
   include CoilDX

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.rb
@@ -14,6 +14,10 @@ class ACM179dASHRAE9012007 < ASHRAE9012007
     @std_2007 = ASHRAE9012007.new
   end
 
+  def almost_equal?(value_actual, value_expected, epsilon = 0.01)
+    (value_actual - value_expected).abs / value_actual < epsilon
+  end
+
   # Loads the openstudio standards dataset for this standard.
   #
   # It will load ASHRAE90.1-2007, and do the following:

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.rb
@@ -55,6 +55,7 @@ class ACM179dASHRAE9012007 < ASHRAE9012007
     end
 
     # override values in 90.1-2007 jsons that are no longer correct compared to the latest 90.1-2007
+    # packaged ac units
     @standards_data['unitary_acs'].each do |info|
       if info['cooling_type'] == 'AirCooled' &&
          info['heating_type'] == 'All Other' &&
@@ -99,7 +100,7 @@ class ACM179dASHRAE9012007 < ASHRAE9012007
         info['minimum_integrated_energy_efficiency_ratio'] = nil
       end
     end
-
+    # boilers
     @standards_data['boilers'].each do |info|
       if info['fluid_type'] == 'Hot Water' &&
          almost_equal?(300000.0, info['minimum_capacity']) &&
@@ -109,7 +110,6 @@ class ACM179dASHRAE9012007 < ASHRAE9012007
         info['minimum_combustion_efficiency'] = nil
       end
     end
-
     @standards_data['boilers'].each do |info|
       if info['fluid_type'] == 'Hot Water' &&
          almost_equal?(2500000.01, info['minimum_capacity']) &&
@@ -117,6 +117,63 @@ class ACM179dASHRAE9012007 < ASHRAE9012007
         info['minimum_thermal_efficiency'] = nil
         info['minimum_annual_fuel_utilization_efficiency'] = nil
         info['minimum_combustion_efficiency'] = 0.82
+      end
+    end
+    # packaged heat pumps
+    @standards_data['heat_pumps'].each do |info|
+      if info['cooling_type'] == 'AirCooled' &&
+         info['heating_type'] == 'All Other' &&
+         info['subcategory'] == 'Single Package' &&
+         almost_equal?(65000.0, info['minimum_capacity']) &&
+         almost_equal?(134999.0, info['maximum_capacity'])
+        info['minimum_seasonal_efficiency'] = nil
+        info['minimum_full_load_efficiency'] = 10.8
+        info['minimum_iplv'] = nil
+        info['minimum_integrated_energy_efficiency_ratio'] = nil
+      end
+    end
+    @standards_data['heat_pumps'].each do |info|
+      if info['cooling_type'] == 'AirCooled' &&
+         info['heating_type'] == 'All Other' &&
+         info['subcategory'] == 'Single Package' &&
+         almost_equal?(135000.0, info['minimum_capacity']) &&
+         almost_equal?(239999.0, info['maximum_capacity'])
+        info['minimum_seasonal_efficiency'] = nil
+        info['minimum_full_load_efficiency'] = 10.4
+        info['minimum_iplv'] = nil
+        info['minimum_integrated_energy_efficiency_ratio'] = nil
+      end
+    end
+    @standards_data['heat_pumps'].each do |info|
+      if info['cooling_type'] == 'AirCooled' &&
+         info['heating_type'] == 'All Other' &&
+         info['subcategory'] == 'Single Package' &&
+         almost_equal?(240000.0, info['minimum_capacity']) &&
+         almost_equal?(9999999.0, info['maximum_capacity'])
+        info['minimum_seasonal_efficiency'] = nil
+        info['minimum_full_load_efficiency'] = 9.3
+        info['minimum_iplv'] = nil
+        info['minimum_integrated_energy_efficiency_ratio'] = nil
+      end
+    end
+    @standards_data['heat_pumps_heating'].each do |info|
+      if info['cooling_type'] == 'AirCooled' &&
+         info['subcategory'] == 'Single Package' &&
+         almost_equal?(65000.0, info['minimum_capacity']) &&
+         almost_equal?(134999.0, info['maximum_capacity'])
+        info['minimum_heating_seasonal_performance_factor'] = nil
+        info['minimum_coefficient_of_performance_heating'] = 3.3
+        info['minimum_energy_efficiency_ratio'] = nil
+      end
+    end
+    @standards_data['heat_pumps_heating'].each do |info|
+      if info['cooling_type'] == 'AirCooled' &&
+         info['subcategory'] == 'Single Package' &&
+         almost_equal?(135000.0, info['minimum_capacity']) &&
+         almost_equal?(9999999.0, info['maximum_capacity'])
+        info['minimum_heating_seasonal_performance_factor'] = nil
+        info['minimum_coefficient_of_performance_heating'] = 3.2
+        info['minimum_energy_efficiency_ratio'] = nil
       end
     end
 

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.rb
@@ -49,5 +49,52 @@ class ACM179dASHRAE9012007 < ASHRAE9012007
         end
       end
     end
+
+    # override values in 90.1-2007 jsons that are no longer correct compared to the latest 90.1-2007
+    @standards_data['unitary_acs'].each do |info|
+      if info['cooling_type'] == 'AirCooled' &&
+         info['heating_type'] == 'All Other' &&
+         info['subcategory'] == 'Single Package' &&
+         almost_equal?(64999.0, info['minimum_capacity']) &&
+         almost_equal?(134999.0, info['maximum_capacity'])
+        info['minimum_energy_efficiency_ratio'] = 11.0
+        info['minimum_seasonal_energy_efficiency_ratio'] = nil
+        info['minimum_integrated_energy_efficiency_ratio'] = nil
+      end
+    end
+    @standards_data['unitary_acs'].each do |info|
+      if info['cooling_type'] == 'AirCooled' &&
+         info['heating_type'] == 'All Other' &&
+         info['subcategory'] == 'Single Package' &&
+         almost_equal?(135000.0, info['minimum_capacity']) &&
+         almost_equal?(239999.0, info['maximum_capacity'])
+        info['minimum_energy_efficiency_ratio'] = 10.8
+        info['minimum_seasonal_energy_efficiency_ratio'] = nil
+        info['minimum_integrated_energy_efficiency_ratio'] = nil
+      end
+    end
+    @standards_data['unitary_acs'].each do |info|
+      if info['cooling_type'] == 'AirCooled' &&
+         info['heating_type'] == 'All Other' &&
+         info['subcategory'] == 'Single Package' &&
+         almost_equal?(240000.0, info['minimum_capacity']) &&
+         almost_equal?(759999.0, info['maximum_capacity'])
+        info['minimum_energy_efficiency_ratio'] = 9.8
+        info['minimum_seasonal_energy_efficiency_ratio'] = nil
+        info['minimum_integrated_energy_efficiency_ratio'] = nil
+      end
+    end
+    @standards_data['unitary_acs'].each do |info|
+      if info['cooling_type'] == 'AirCooled' &&
+         info['heating_type'] == 'All Other' &&
+         info['subcategory'] == 'Single Package' &&
+         almost_equal?(760000.0, info['minimum_capacity']) &&
+         almost_equal?(9999999.0, info['maximum_capacity'])
+        info['minimum_energy_efficiency_ratio'] = 9.5
+        info['minimum_seasonal_energy_efficiency_ratio'] = nil
+        info['minimum_integrated_energy_efficiency_ratio'] = nil
+      end
+    end
+
   end
 end

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.rb
@@ -96,5 +96,25 @@ class ACM179dASHRAE9012007 < ASHRAE9012007
       end
     end
 
+    @standards_data['boilers'].each do |info|
+      if info['fluid_type'] == 'Hot Water' &&
+         almost_equal?(300000.0, info['minimum_capacity']) &&
+         almost_equal?(2500000.0, info['maximum_capacity'])
+        info['minimum_thermal_efficiency'] = 0.8
+        info['minimum_annual_fuel_utilization_efficiency'] = nil
+        info['minimum_combustion_efficiency'] = nil
+      end
+    end
+
+    @standards_data['boilers'].each do |info|
+      if info['fluid_type'] == 'Hot Water' &&
+         almost_equal?(2500000.01, info['minimum_capacity']) &&
+         almost_equal?(9999999999.0, info['maximum_capacity'])
+        info['minimum_thermal_efficiency'] = nil
+        info['minimum_annual_fuel_utilization_efficiency'] = nil
+        info['minimum_combustion_efficiency'] = 0.82
+      end
+    end
+
   end
 end


### PR DESCRIPTION
- coming from this: https://openstudioteam.slack.com/archives/C06RL410GMC/p1721957094166289

- corresponding changes for this: https://github.com/NREL/openstudio-bem-to-surrogate-gem/pull/175

- table below shows the summary of the changes in this PR:

![image](https://github.com/user-attachments/assets/6e3c6942-9fff-4035-ac49-7c4da7403c65)
 