### PR TITLE
Unmet load hours check opt in in model_create_prm_baseline_building

### DIFF
--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.Model.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.Model.rb
@@ -286,8 +286,8 @@ class ACM179dASHRAE9012007
   # @param sizing_run_dir [String] the directory where the sizing runs will be performed
   # @param debug [Boolean] If true, will report out more detailed debugging output
   # @param baseline_179d [Boolean] NOTE: 179D addition, True for the baseline, false for the proposed
-  def model_create_prm_baseline_building(model, building_type, climate_zone, custom = nil, sizing_run_dir = Dir.pwd, debug = false, baseline_179d = true)
-    model_create_prm_any_baseline_building(model, building_type, climate_zone, 'All others', 'All others', 'All others', false, custom, sizing_run_dir, false, false, debug, baseline_179d)
+  def model_create_prm_baseline_building(model, building_type, climate_zone, custom = nil, sizing_run_dir = Dir.pwd, debug = false, baseline_179d = true, unmet_load_hours_check = false)
+    model_create_prm_any_baseline_building(model, building_type, climate_zone, 'All others', 'All others', 'All others', false, custom, sizing_run_dir, false, unmet_load_hours_check, debug, baseline_179d)
   end
 
   # Creates a Performance Rating Method (aka Appendix G aka LEED) baseline building model


### PR DESCRIPTION
1. Make the unmet_load_hours_check a parameter.


2. Revamp the sizing factor adjustment rounds

* nb_adjustments was never incremented
* The max sizing factor wasn't really capped at 2.0
* I made the max_adjustment and max_sizing factors adjustable
* I revamped the flow so it's clear what's happening, and it runs into subdirs
* I am using a function to calculate the sizing factor multiplier
     * Instead of using 1.1 if unmet hours > 150 and 1.05 if > 50
     * I instead apply a linear function that will evaluate the same at 50 and 150 but will be much more aggressive if you have say 1000 unmet hours.
