### PR TITLE
Backport thermal_zone_convert_outdoor_air_to_per_area from newer openstudio-standards

### DIFF
--- a/lib/openstudio-standards.rb
+++ b/lib/openstudio-standards.rb
@@ -243,9 +243,16 @@ module OpenstudioStandards
 
   # 179D
   require_relative "#{stds}/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.Model"
+  require_relative "#{stds}/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.AirLoopHVAC"
+  require_relative "#{stds}/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.AirTerminalSingleDuctVAVReheat"
+  require_relative "#{stds}/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.CoilHeatingDXMultiSpeed"
+  require_relative "#{stds}/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.CoilHeatingDXSingleSpeed"
+  require_relative "#{stds}/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.FanVariableVolume"
+  require_relative "#{stds}/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.PlanarSurface"
+  require_relative "#{stds}/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.PlantLoop"
   require_relative "#{stds}/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.SpaceType"
   require_relative "#{stds}/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.SubSurface"
-  require_relative "#{stds}/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.PlantLoop"
+  require_relative "#{stds}/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.ThermalZone"
   require_relative "#{stds}/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.ZoneHVACComponent"
 
   # 90.1-2010


### PR DESCRIPTION
Coming from,
- https://github.com/NREL/openstudio-bem-to-surrogate-gem/pull/202
- https://github.com/jmarrec/openstudio-standards/pull/27

I believe we can't use `OpenstudioStandards::ThermalZone` in our OS version 3.6.1 because it's a newer thing. I just noticed this while testing new measure. Need to open a companion PR on the 179D bem workflow side too.

* Companion PR: https://github.com/NREL/openstudio-bem-to-surrogate-gem/pull/280