### PR TITLE
Fix/enable DCV in proposed model (port from BEM PR #421)

### DIFF
--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.AirLoopHVAC.rb
@@ -239,22 +239,23 @@ class ACM179dASHRAE9012007
       ## end
     end
 
-    # DCV
-    # only apply DCV in baseline
-    if baseline_179d
-      if air_loop_hvac_demand_control_ventilation_required?(air_loop_hvac, climate_zone)
-        air_loop_hvac_enable_demand_control_ventilation(air_loop_hvac, climate_zone)
-        # For systems that require DCV,
-        # all individual zones that require DCV preserve
-        # both per-area and per-person OA requirements.
-        # Other zones have OA requirements converted
-        # to per-area values only so DCV performance is only
-        # based on the subset of zones that required DCV.
-        OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: Converting ventilation requirements to per-area for all zones served that do not require DCV.")
-        air_loop_hvac.thermalZones.sort.each do |zone|
-          unless thermal_zone_demand_control_ventilation_required?(zone, climate_zone)
-            thermal_zone_convert_oa_req_to_per_area(zone)
-          end
+    # DCV — apply per 90.1-2007 §6.4.3.9 / 90.1-2019 §6.4.3.8 in both proposed
+    # and baseline. Previously gated on baseline_179d; that gating produced an
+    # inverted OA comparison (proposed delivered full Vot continuously while
+    # baseline modulated by occupancy) and a code-noncompliant proposed model.
+    # See DCV-PROPOSED-VS-BASELINE-HISTORY.md.
+    if air_loop_hvac_demand_control_ventilation_required?(air_loop_hvac, climate_zone)
+      air_loop_hvac_enable_demand_control_ventilation(air_loop_hvac, climate_zone)
+      # For systems that require DCV,
+      # all individual zones that require DCV preserve
+      # both per-area and per-person OA requirements.
+      # Other zones have OA requirements converted
+      # to per-area values only so DCV performance is only
+      # based on the subset of zones that required DCV.
+      OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: Converting ventilation requirements to per-area for all zones served that do not require DCV.")
+      air_loop_hvac.thermalZones.sort.each do |zone|
+        unless thermal_zone_demand_control_ventilation_required?(zone, climate_zone)
+          thermal_zone_convert_oa_req_to_per_area(zone)
         end
       end
     end

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.Model.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.Model.rb
@@ -1201,6 +1201,17 @@ class ACM179dASHRAE9012007
       controller_oa = air_loop_hvac_oasys.getControllerOutdoorAir
       sizing_system = air_loop.sizingSystem
 
+      # When DCV is enabled, Controller:OutdoorAir.MinimumOutdoorAirFlowRate is 0
+      # by design (DCV modulates Vbz via Controller:MechanicalVentilation at
+      # runtime). Sizing:System.designOutdoorAirFlowRate must keep the VRP-computed
+      # Vot from model_apply_multizone_vav_outdoor_air_sizing — propagating the
+      # Controller zero here would undersize the AHU and zero out the design OA.
+      controller_mv = controller_oa.controllerMechanicalVentilation
+      if controller_mv.demandControlledVentilation
+        OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.Model', "Skipping OA rate force for '#{air_loop.nameString}': DCV enabled — Sizing:System retains VRP-computed Vot.")
+        next
+      end
+
       # get minimum outdoor airflow rate from Controller:OutdoorAir
       minimum_outdoor_airflow_rate_m_3_per_s = nil
       if controller_oa.minimumOutdoorAirFlowRate.is_initialized


### PR DESCRIPTION
Port of changes from NatLabRockies/openstudio-bem-to-surrogate-gem#421.

## Changes

### `179d_ashrae_90_1_2007.AirLoopHVAC.rb`
- Remove the `if baseline_179d` guard around the DCV block so that DCV is applied in both the proposed and baseline models
- - Update the comment to explain why: the previous gating produced an inverted OA comparison (proposed delivered full Vot continuously while baseline modulated by occupancy), resulting in a code-noncompliant proposed model
### `179d_ashrae_90_1_2007.Model.rb`
- In `consistent_outdoor_airflow_rate`, skip the OA rate override for air loops that have DCV enabled
- - When DCV is active, `Controller:OutdoorAir.MinimumOutdoorAirFlowRate` is intentionally 0 (DCV modulates Vbz via `Controller:MechanicalVentilation` at runtime); propagating that zero to `Sizing:System.designOutdoorAirFlowRate` would undersize the AHU and zero out the design OA