### PR TITLE
Enable DCV in proposed model (port BEM PR #421 onto 0.8.2 / 179D_310)

### DIFF
--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.AirLoopHVAC.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.AirLoopHVAC.rb
@@ -239,22 +239,23 @@ class ACM179dASHRAE9012007
       ## end
     end
 
-    # DCV
-    # only apply DCV in baseline
-    if baseline_179d
-      if air_loop_hvac_demand_control_ventilation_required?(air_loop_hvac, climate_zone)
-        air_loop_hvac_enable_demand_control_ventilation(air_loop_hvac, climate_zone)
-        # For systems that require DCV,
-        # all individual zones that require DCV preserve
-        # both per-area and per-person OA requirements.
-        # Other zones have OA requirements converted
-        # to per-area values only so DCV performance is only
-        # based on the subset of zones that required DCV.
-        OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: Converting ventilation requirements to per-area for all zones served that do not require DCV.")
-        air_loop_hvac.thermalZones.sort.each do |zone|
-          unless thermal_zone_demand_control_ventilation_required?(zone, climate_zone)
-            thermal_zone_convert_oa_req_to_per_area(zone)
-          end
+    # DCV — apply per 90.1-2007 §6.4.3.9 / 90.1-2019 §6.4.3.8 in both proposed
+    # and baseline. Previously gated on baseline_179d; that gating produced an
+    # inverted OA comparison (proposed delivered full Vot continuously while
+    # baseline modulated by occupancy) and a code-noncompliant proposed model.
+    # See DCV-PROPOSED-VS-BASELINE-HISTORY.md.
+    if air_loop_hvac_demand_control_ventilation_required?(air_loop_hvac, climate_zone)
+      air_loop_hvac_enable_demand_control_ventilation(air_loop_hvac, climate_zone)
+      # For systems that require DCV,
+      # all individual zones that require DCV preserve
+      # both per-area and per-person OA requirements.
+      # Other zones have OA requirements converted
+      # to per-area values only so DCV performance is only
+      # based on the subset of zones that required DCV.
+      OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}: Converting ventilation requirements to per-area for all zones served that do not require DCV.")
+      air_loop_hvac.thermalZones.sort.each do |zone|
+        unless thermal_zone_demand_control_ventilation_required?(zone, climate_zone)
+          OpenstudioStandards::ThermalZone.thermal_zone_convert_outdoor_air_to_per_area(zone)
         end
       end
     end

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.Model.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.Model.rb
@@ -1271,6 +1271,17 @@ class ACM179dASHRAE9012007
       controller_oa = air_loop_hvac_oasys.getControllerOutdoorAir
       sizing_system = air_loop.sizingSystem
 
+      # When DCV is enabled, Controller:OutdoorAir.MinimumOutdoorAirFlowRate is 0
+      # by design (DCV modulates Vbz via Controller:MechanicalVentilation at
+      # runtime). Sizing:System.designOutdoorAirFlowRate must keep the VRP-computed
+      # Vot from model_apply_multizone_vav_outdoor_air_sizing — propagating the
+      # Controller zero here would undersize the AHU and zero out the design OA.
+      controller_mv = controller_oa.controllerMechanicalVentilation
+      if controller_mv.demandControlledVentilation
+        OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.Model', "Skipping OA rate force for '#{air_loop.nameString}': DCV enabled — Sizing:System retains VRP-computed Vot.")
+        next
+      end
+
       # get minimum outdoor airflow rate from Controller:OutdoorAir
       minimum_outdoor_airflow_rate_m_3_per_s = nil
       if controller_oa.minimumOutdoorAirFlowRate.is_initialized


### PR DESCRIPTION
Companion port of NatLabRockies/openstudio-bem-to-surrogate-gem#421 onto the **0.8.2 / OS 3.10** base (`179D_310`).

Supersedes #49, which was opened against `179D` (openstudio-standards **0.4.1**) — wrong base for the 3.10 switch. On 0.4.1 the per-area helper is still the `thermal_zone_convert_oa_req_to_per_area` instance method; on 0.8.2 that method was removed in favor of the `OpenstudioStandards::ThermalZone` module fn, so #49's code would `NoMethodError` here. This PR targets `179D_310` and uses the 0.8.2 namespace.

## Changes

### `179d_ashrae_90_1_2007.AirLoopHVAC.rb`
- Remove the `if baseline_179d` guard around the DCV block so DCV is applied in **both** proposed and baseline. The old gating produced an inverted OA comparison (proposed delivered full Vot continuously while baseline modulated by occupancy) and a code-noncompliant proposed model.
- Switch the per-area conversion to the 0.8.2 module function `OpenstudioStandards::ThermalZone.thermal_zone_convert_outdoor_air_to_per_area`. (`179D_310` previously still called the removed `thermal_zone_convert_oa_req_to_per_area` — a latent `NoMethodError` this also fixes.)

### `179d_ashrae_90_1_2007.Model.rb`
- In `consistent_outdoor_airflow_rate`, skip the OA-rate force for air loops with DCV enabled. When DCV is active, `Controller:OutdoorAir.MinimumOutdoorAirFlowRate` is intentionally 0 (DCV modulates Vbz via `Controller:MechanicalVentilation` at runtime); propagating that zero into `Sizing:System.designOutdoorAirFlowRate` would undersize the AHU and zero out design OA.

Both files pass `ruby -c`. Logic mirrors BEM PR #421's core files verbatim (namespace-adjusted for 0.8.2).
