### PR TITLE
Companion port for BEM PR #418: 179D warehouse non-mechanical cooling

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+# Copilot instructions
+
+Do not add `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` to commit messages or commit bodies.

--- a/lib/openstudio-standards/create_typical/create_typical.rb
+++ b/lib/openstudio-standards/create_typical/create_typical.rb
@@ -816,6 +816,18 @@ module OpenstudioStandards
         # adjust infiltration schedules
         if add_infiltration
           OpenstudioStandards::Infiltration.model_set_nist_infiltration_schedules(model)
+
+          if template == '179D 90.1-2007' && primary_bldg_type == 'Warehouse'
+            heated_only_zones_with_zvs = model.getThermalZones.select do |zone|
+              next false unless zone.airLoopHVAC.empty?
+
+              zone.equipment.any? do |eq|
+                zv = eq.to_ZoneVentilationDesignFlowRate
+                zv.is_initialized && zv.get.nameString.end_with?(' Ventilation')
+              end
+            end
+            standard.model_add_ddy_only_infiltration_for_heated_only_zones(model, heated_only_zones_with_zvs)
+          end
         end
       end
 

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.Model.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.Model.rb
@@ -258,10 +258,17 @@ class ACM179dASHRAE9012007
       end
     end
 
-    # Also sync the occupied schedule to " Ventilation" ZoneVentilationDesignFlowRate objects.
-    # These are created before this method runs (during HVAC setup), so they initially inherit
-    # alwaysOnDiscreteSchedule from the unit heater. Apply the ACM schedule here to keep them in sync.
-    ventilation_zvs = model.getZoneVentilationDesignFlowRates.select { |zv| zv.nameString.end_with?(' Ventilation') }
+    # Also sync the occupied schedule to the heated-only zone " Ventilation"
+    # ZoneVentilationDesignFlowRate objects. These are created before this
+    # method runs (during HVAC setup), so they initially inherit
+    # alwaysOnDiscreteSchedule from the unit heater. Keep the sync limited to
+    # standalone zones so it does not disturb zone ventilation used by other
+    # prototypes.
+    ventilation_zvs = model.getZoneVentilationDesignFlowRates.select do |zv|
+      next false unless zv.nameString.end_with?(' Ventilation')
+      next false unless zv.thermalZone.is_initialized
+      zv.thermalZone.get.airLoopHVAC.empty?
+    end
     unless ventilation_zvs.empty?
       if acm_fan_sch.nil?
         acm_fan_sch = model_add_schedule(model, acm_fan_sch_name)
@@ -717,7 +724,13 @@ class ACM179dASHRAE9012007
 
           if baseline_179d && ['Gas_Furnace', 'Electric_Furnace'].include?(system_type[0])
             OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.Model', "179D - For Unit Heater, adding a ZoneVentilationDesignFlowRate for outside air requirements")
-            model_add_equivalent_zone_ventilation_for_heated_only_zones_with_dsoa(model, sys_group['zones'], ventilation_type: 'Exhaust', ensure_ddy_infiltration: true)
+            model_add_equivalent_zone_ventilation_for_heated_only_zones_with_dsoa(
+              model,
+              sys_group['zones'],
+              ventilation_type: 'Exhaust',
+              ensure_ddy_infiltration: true,
+              add_cooling_exhaust: building_type == 'Warehouse',
+            )
           end
 
           model.getAirLoopHVACs.each do |air_loop|

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.Model.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.Model.rb
@@ -258,6 +258,21 @@ class ACM179dASHRAE9012007
       end
     end
 
+    # Also sync the occupied schedule to " Ventilation" ZoneVentilationDesignFlowRate objects.
+    # These are created before this method runs (during HVAC setup), so they initially inherit
+    # alwaysOnDiscreteSchedule from the unit heater. Apply the ACM schedule here to keep them in sync.
+    ventilation_zvs = model.getZoneVentilationDesignFlowRates.select { |zv| zv.nameString.end_with?(' Ventilation') }
+    unless ventilation_zvs.empty?
+      if acm_fan_sch.nil?
+        acm_fan_sch = model_add_schedule(model, acm_fan_sch_name)
+        model.getBuilding.additionalProperties.setFeature('acm_fan_sch', acm_fan_sch_name)
+      end
+      ventilation_zvs.each do |zv|
+        zv.setSchedule(acm_fan_sch)
+        count_availability += 1
+      end
+    end
+
     OpenStudio.logFree(OpenStudio::Info, 'openstudio.model_apply_acm_hvac_availability_schedule', "Applied availablity schedule '#{acm_fan_sch_name}' to #{count_availability} objects.")
     return count_availability > 0
   end
@@ -1084,88 +1099,275 @@ class ACM179dASHRAE9012007
     end
   end
 
+  def _zone_has_exterior_connection?(zone, minimum_exterior_area_m2: 0.001)
+    zone.spaces.any? { |space| space.exteriorArea > minimum_exterior_area_m2 }
+  end
+
+  def _find_exterior_source_zone_for_interior_zone(interior_zone, exterior_zones)
+    return nil if exterior_zones.empty?
+
+    exterior_zone_handles = exterior_zones.map { |z| z.handle.to_s }
+    interior_zone.spaces.each do |space|
+      space.surfaces.each do |surface|
+        next unless surface.adjacentSurface.is_initialized
+
+        adjacent_surface = surface.adjacentSurface.get
+        next unless adjacent_surface.space.is_initialized
+
+        adjacent_space = adjacent_surface.space.get
+        next unless adjacent_space.thermalZone.is_initialized
+
+        adjacent_zone = adjacent_space.thermalZone.get
+        return adjacent_zone if exterior_zone_handles.include?(adjacent_zone.handle.to_s)
+      end
+    end
+
+    fallback_zone = exterior_zones.max_by(&:floorArea)
+    OpenStudio.logFree(
+      OpenStudio::Warn, 'openstudio.179D.Model',
+      "No adjacent exterior zone found for interior zone '#{interior_zone.nameString}'; using largest exterior zone '#{fallback_zone.nameString}' as source for mixing."
+    )
+    fallback_zone
+  end
+
+  def _apply_cooling_exhaust_gate_to_zone_ventilation(zone_ventilation, zone, cooling_exhaust_delta_t_c:)
+    # Trigger: activate when indoor temp exceeds the thermostat cooling setpoint.
+    # Using the schedule allows this to track any thermostat updates automatically.
+    if zone.thermostatSetpointDualSetpoint.is_initialized
+      tstat = zone.thermostatSetpointDualSetpoint.get
+      if tstat.coolingSetpointTemperatureSchedule.is_initialized
+        zone_ventilation.setMinimumIndoorTemperatureSchedule(tstat.coolingSetpointTemperatureSchedule.get)
+      else
+        zone_ventilation.setMinimumIndoorTemperature(40.0)
+      end
+    else
+      zone_ventilation.setMinimumIndoorTemperature(40.0)
+    end
+
+    zone_ventilation.setMaximumIndoorTemperature(100.0)
+    # Only provide free cooling when outdoor is measurably cooler than indoor
+    zone_ventilation.setDeltaTemperature(cooling_exhaust_delta_t_c)
+    # Don't run when outdoor is very cold (no overheating risk near-freezing)
+    zone_ventilation.setMinimumOutdoorTemperature(13.0)
+    zone_ventilation.setMaximumOutdoorTemperature(100.0)
+  end
+
   # For Heated Only Zones, System 9 or 10, there will be zero outside air
-  # actually brought in, because the ZoneHVACUnitHeater does add OA.
+  # actually brought in, because the ZoneHVACUnitHeater does not provide OA.
   # While this has very little effect in most of the building types (heated
-  # only zones are small), this is problematic for the Warehouse in particular
-  # This method will look on such zones, and for each zone it will find the
+  # only zones are small), this is problematic for the Warehouse in particular.
+  # This method will look at such zones, and for each zone it will find the
   # DesignSpecificationOutdoorAir objects for the spaces and compute an
-  # equivalent OA flow rate, and create a ZoneVentilationDesignFlowRate object
-  # to match it.
+  # equivalent OA flow rate.
+  #
+  # A ventilation ZoneVentilationDesignFlowRate object is created per zone:
+  #
+  # 1. **Ventilation exhaust** (year-round occupied): sized to the code-minimum
+  #    OA requirement, runs on the zone's HVAC availability schedule (occupied
+  #    hours), temperature limits are permissive — this satisfies IAQ requirements
+  #    for the heating-only zone.
+  #
+  # If add_cooling_exhaust is enabled:
+  # * Interior zones get a **Cooling Exhaust** object.
+  # * Exterior-connected zones get a thermostat-gated **Cooling Makeup Air Intake**
+  #   object (to avoid double counting simultaneous exhaust+intake OA at the same
+  #   design flow in a single zone).
+  # * Interior zones get always-on **ZoneMixing** from an exterior source zone.
+  # * Exterior source zones get always-on **Mixing Makeup Air Intake** objects sized
+  #   to the total outgoing interior mixing flow.
+  #
   # @param ventilation_type [String] one of:
-  #   * 'Natural', 'Intake' (Supply Fanfloor area (m^2)
+  #   * 'Natural': no fan power (0 W/CFM)
   #   * 'Intake': System 9 and 10 supply fan, 0.3 W/CFM
-  #   * 'Exahsut': System 9 and 10 non-mechanical cooling, 0.054 W/CFM
-  # @param ensure_ddy_infiltration [Boolean]:
-  #   * If true, will check that the spaces do have some ACH, or will define a
-  #   SpaceInfiltrationDesignFlowRate only active during design days that
-  #   matches the space's DesignSpecificationOutdoorAir
-  def model_add_equivalent_zone_ventilation_for_heated_only_zones_with_dsoa(model, zones, ventilation_type: 'Natural', ensure_ddy_infiltration: true)
+  #   * 'Exhaust': System 9 and 10 non-mechanical cooling, 0.054 W/CFM
+  # @param ensure_ddy_infiltration [Boolean]: if true, checks that spaces have
+  #   some ACH and adds a design-day-only infiltration object that matches the
+  #   space DSOA to avoid sizing errors.
+  # @param add_cooling_exhaust [Boolean]: if true, adds a second, higher-flow
+  #   exhaust object controlled by the thermostat cooling setpoint.
+  # @param cooling_exhaust_flow_per_area_m3_per_s_per_m2 [Float, nil]: cooling
+  #   exhaust flow rate per floor area. Defaults to ~0.27 CFM/ft² (0.00137
+  #   m³/s·m²) based on ASHRAE heat-balance sizing.
+  # @param cooling_exhaust_delta_t_c [Float]: minimum indoor-minus-outdoor
+  #   temperature difference (°C) required for the cooling exhaust to operate.
+  #   Default 2.0°C prevents operation when outdoor air provides no cooling benefit.
+  # @param interior_zone_mixing_flow_fraction [Float, nil]: optional multiplier
+  #   on interior-zone always-on mixing flow. If nil, this can be calibrated via
+  #   building additional property `179d_interior_zone_mixing_flow_fraction`.
+  #   Defaults to 1.0 if not provided.
+  def model_add_equivalent_zone_ventilation_for_heated_only_zones_with_dsoa(
+    model, zones,
+    ventilation_type: 'Natural',
+    ensure_ddy_infiltration: true,
+    add_cooling_exhaust: false,
+    cooling_exhaust_flow_per_area_m3_per_s_per_m2: nil,
+    cooling_exhaust_delta_t_c: 2.0,
+    interior_zone_mixing_flow_fraction: nil
+  )
+    cooling_flow_m3_per_s_per_m2 = cooling_exhaust_flow_per_area_m3_per_s_per_m2 ||
+                                   OpenStudio.convert(0.27, 'CFM/ft^2', 'm^3/s*m^2').get
+
+    case ventilation_type
+    when 'Natural'
+      pressure_rise_pa = 0.0
+      fan_total_eff = 1.0
+    when 'Intake'
+      target_w_per_m3_per_s = OpenStudio.convert(0.3, 'W/CFM', 'W*s/m^3').get
+      fan_total_eff = 0.6
+      pressure_rise_pa = fan_total_eff * target_w_per_m3_per_s
+    when 'Exhaust'
+      target_w_per_m3_per_s = OpenStudio.convert(0.054, 'W/CFM', 'W*s/m^3').get
+      fan_total_eff = 0.6
+      pressure_rise_pa = fan_total_eff * target_w_per_m3_per_s
+    else
+      raise "ventilation_type must be one of ['Natural', 'Intake', 'Exhaust']"
+    end
+
+    occupied_sched = nil
+    acm_sch_name_opt = model.getBuilding.additionalProperties.getFeatureAsString('acm_fan_sch')
+    if acm_sch_name_opt.is_initialized
+      occupied_sched = model_add_schedule(model, acm_sch_name_opt.get)
+    end
+    if occupied_sched.nil?
+      begin
+        data = model_get_standards_data(model)
+        acm_sch_name = data['hvac_operation_schedule']
+        occupied_sched = model_add_schedule(model, acm_sch_name) if acm_sch_name
+      rescue StandardError
+        # Fall back to always-on
+      end
+    end
+
+    mixing_flow_fraction = interior_zone_mixing_flow_fraction
+    if mixing_flow_fraction.nil?
+      mixing_flow_fraction_opt = model.getBuilding.additionalProperties.getFeatureAsDouble('179d_interior_zone_mixing_flow_fraction')
+      mixing_flow_fraction = mixing_flow_fraction_opt.is_initialized ? mixing_flow_fraction_opt.get : 1.0
+    end
+    raise 'interior_zone_mixing_flow_fraction must be >= 0.0' if mixing_flow_fraction < 0.0
+
+    eligible_zone_total_floor_area_m2 = 0.0
+    eligible_interior_zone_total_floor_area_m2 = 0.0
+    eligible_exterior_zone_total_floor_area_m2 = 0.0
     zones.sort.each do |zone|
-      total_oa_m3_per_s = OpenstudioStandards::ThermalZone.thermal_zone_get_outdoor_airflow_rate(zone)
-
-      total_oa_m3_per_m2s = total_oa_m3_per_s / zone.floorArea
-
+      begin
+        total_oa_m3_per_s = OpenstudioStandards::ThermalZone.thermal_zone_get_outdoor_airflow_rate(zone)
+      rescue StandardError
+        next
+      end
       next unless total_oa_m3_per_s > 0
 
-      # ventilation = model_add_zone_ventilation(model, sys_group['zones'], ventilation_type: 'Natural', flow_rate: total_oa_m3_per_s).first
+      eligible_zone_total_floor_area_m2 += zone.floorArea
+      if _zone_has_exterior_connection?(zone)
+        eligible_exterior_zone_total_floor_area_m2 += zone.floorArea
+        next
+      end
 
-      tot_oa_cfm = OpenStudio.convert(total_oa_m3_per_s, 'm^3/s', 'cfm').get.round(2)
-      total_oa_cfm_per_sqft = OpenStudio.convert(total_oa_m3_per_m2s, 'm^3/m^2*s', 'cfm/ft^2').get.round(4)
+      eligible_interior_zone_total_floor_area_m2 += zone.floorArea
+    end
 
-      OpenStudio.logFree(
-        OpenStudio::Info, 'openstudio.179D.Model',
-        "Adding zone ventilation fan for #{zone.name} - #{tot_oa_cfm} CFM total - #{total_oa_cfm_per_sqft} CFM/ft^2"
-      )
+    interior_cooling_exhaust_flow_m3_per_s_per_m2 = cooling_flow_m3_per_s_per_m2
+    exterior_cooling_makeup_flow_m3_per_s_per_m2 = cooling_flow_m3_per_s_per_m2
+    if add_cooling_exhaust
+      if eligible_interior_zone_total_floor_area_m2 > 0.0
+        interior_cooling_exhaust_flow_m3_per_s_per_m2 = cooling_flow_m3_per_s_per_m2 *
+                                                         (eligible_zone_total_floor_area_m2 / eligible_interior_zone_total_floor_area_m2)
+      else
+        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.179D.Model', 'No interior heated-only zones found for cooling exhaust renormalization; using default cooling exhaust flow.')
+      end
+
+      if eligible_exterior_zone_total_floor_area_m2 > 0.0
+        exterior_cooling_makeup_flow_m3_per_s_per_m2 = cooling_flow_m3_per_s_per_m2 *
+                                                        (eligible_zone_total_floor_area_m2 / eligible_exterior_zone_total_floor_area_m2)
+      else
+        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.179D.Model', 'No exterior heated-only zones found for cooling make-up intake renormalization; using default cooling make-up intake flow.')
+      end
+    end
+
+    zone_data_by_handle = {}
+    zones.sort.each do |zone|
+      begin
+        total_oa_m3_per_s = OpenstudioStandards::ThermalZone.thermal_zone_get_outdoor_airflow_rate(zone)
+      rescue StandardError => e
+        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.179D.Model', "Skipping zone #{zone.name} due to standards lookup error: #{e.message}")
+        next
+      end
+
+      total_oa_m3_per_m2s = total_oa_m3_per_s / zone.floorArea
+      next unless total_oa_m3_per_s > 0
+
+      zone_data_by_handle[zone.handle.to_s] = {
+        zone: zone,
+        has_exterior_connection: _zone_has_exterior_connection?(zone),
+        base_cooling_flow_m3_per_s: cooling_flow_m3_per_s_per_m2 * zone.floorArea
+      }
 
       ventilation = OpenStudio::Model::ZoneVentilationDesignFlowRate.new(model)
       ventilation.setName("#{zone.name} Ventilation")
-      ventilation.setSchedule(model.alwaysOnDiscreteSchedule)
-
-      # Per Flow Area is clearer in intent, because that's what we
-      # mostly have in our standards data
-      # ventilation.setDesignFlowRate(total_oa_m3_per_s)
+      ventilation.setSchedule(occupied_sched || model.alwaysOnDiscreteSchedule)
       ventilation.setFlowRateperZoneFloorArea(total_oa_m3_per_m2s)
-
-      # Make it run all the time, with the design flow rate
       ventilation.setConstantTermCoefficient(1.0)
       ventilation.setVelocityTermCoefficient(0.0)
       ventilation.setTemperatureTermCoefficient(0.0)
       ventilation.setMinimumIndoorTemperature(-73.3333352760033)
       ventilation.setMaximumIndoorTemperature(100.0)
       ventilation.setDeltaTemperature(-100.0)
-
-      if ventilation_type == 'Natural'
-        # No fan power
-        pressure_rise_pa = 0.0
-        fan_total_eff = 1.0
-      elsif ventilation_type == 'Intake'
-        # System Type 9 and 10 (supply fan): Pfan = CFM * 0.3
-        target_w_per_m3_per_s = OpenStudio.convert(0.3, 'W/CFM', 'W*s/m^3').get()
-        fan_total_eff = 0.6
-        pressure_rise_pa = fan_total_eff * target_w_per_m3_per_s
-      elsif ventilation_type == 'Exhaust'
-        # System Type 9 and 10 (non-mechanical cooling fan
-        # if required by Section G3.1.2.8.2): Pfan = CFM * 0.054
-        target_w_per_m3_per_s = OpenStudio.convert(0.054, 'W/CFM', 'W*s/m^3').get()
-        fan_total_eff = 0.6
-        pressure_rise_pa = fan_total_eff * target_w_per_m3_per_s
-      else
-        raise "ventilation_type must be one of ['Natural', 'Intake', 'Exhaust']"
-      end
-
       ventilation.setVentilationType(ventilation_type)
       ventilation.setFanPressureRise(pressure_rise_pa)
       ventilation.setFanTotalEfficiency(fan_total_eff)
-
-      # Add to Thermal Zone, and clarify that it's first in line
-      # before the UnitHeater, so that it "sees" the load introduced
-      # (In E+, this isn't part of the ZoneHVAC:EquipmentList anyways)
       ventilation.addToThermalZone(zone)
       zone.setHeatingPriority(ventilation, 0)
       zone.setCoolingPriority(ventilation, 0)
 
-      return unless ensure_ddy_infiltration
+      if add_cooling_exhaust
+        zone_data = zone_data_by_handle[zone.handle.to_s]
+        if zone_data[:has_exterior_connection]
+          intake_name = "#{zone.name} Cooling Makeup Air Intake"
+          cooling_makeup_intake = zone.equipment.filter_map do |eq|
+            zv = eq.to_ZoneVentilationDesignFlowRate
+            zv.get if zv.is_initialized && zv.get.nameString == intake_name
+          end.first
+          if cooling_makeup_intake.nil?
+            cooling_makeup_intake = OpenStudio::Model::ZoneVentilationDesignFlowRate.new(model)
+            cooling_makeup_intake.setName(intake_name)
+            cooling_makeup_intake.setSchedule(model.alwaysOnDiscreteSchedule)
+            cooling_makeup_intake.setFlowRateperZoneFloorArea(exterior_cooling_makeup_flow_m3_per_s_per_m2)
+            cooling_makeup_intake.setConstantTermCoefficient(1.0)
+            cooling_makeup_intake.setVelocityTermCoefficient(0.0)
+            cooling_makeup_intake.setTemperatureTermCoefficient(0.0)
+            _apply_cooling_exhaust_gate_to_zone_ventilation(cooling_makeup_intake, zone, cooling_exhaust_delta_t_c: cooling_exhaust_delta_t_c)
+            cooling_makeup_intake.setVentilationType('Intake')
+            cooling_makeup_intake.setFanPressureRise(0.0)
+            cooling_makeup_intake.setFanTotalEfficiency(1.0)
+            cooling_makeup_intake.addToThermalZone(zone)
+            zone.setHeatingPriority(cooling_makeup_intake, 0)
+            zone.setCoolingPriority(cooling_makeup_intake, 0)
+          end
+        else
+          cooling_exhaust_name = "#{zone.name} Cooling Exhaust"
+          has_cooling_exhaust = zone.equipment.any? do |eq|
+            zv = eq.to_ZoneVentilationDesignFlowRate
+            zv.is_initialized && zv.get.nameString == cooling_exhaust_name
+          end
+          unless has_cooling_exhaust
+            cooling_exhaust = OpenStudio::Model::ZoneVentilationDesignFlowRate.new(model)
+            cooling_exhaust.setName(cooling_exhaust_name)
+            cooling_exhaust.setSchedule(model.alwaysOnDiscreteSchedule)
+            cooling_exhaust.setFlowRateperZoneFloorArea(interior_cooling_exhaust_flow_m3_per_s_per_m2)
+            cooling_exhaust.setConstantTermCoefficient(1.0)
+            cooling_exhaust.setVelocityTermCoefficient(0.0)
+            cooling_exhaust.setTemperatureTermCoefficient(0.0)
+            _apply_cooling_exhaust_gate_to_zone_ventilation(cooling_exhaust, zone, cooling_exhaust_delta_t_c: cooling_exhaust_delta_t_c)
+            cooling_exhaust.setVentilationType(ventilation_type)
+            cooling_exhaust.setFanPressureRise(pressure_rise_pa)
+            cooling_exhaust.setFanTotalEfficiency(fan_total_eff)
+            cooling_exhaust.addToThermalZone(zone)
+            zone.setHeatingPriority(cooling_exhaust, 0)
+            zone.setCoolingPriority(cooling_exhaust, 0)
+          end
+        end
+      end
+
+      next unless ensure_ddy_infiltration
 
       zone.spaces.each do |space|
         next if space.infiltrationDesignAirChangesPerHour > 0.001
@@ -1174,15 +1376,94 @@ class ACM179dASHRAE9012007
         spi.setSpace(space)
         spi.setSchedule(_get_or_create_ddy_only_infiltration_schedule(model))
         if space.designSpecificationOutdoorAir.is_initialized
-          spi.setFlowperSpaceFloorArea(space_get_outdoor_airflow_rate(space) / space.floorArea())
+          spi.setFlowperSpaceFloorArea(space_get_outdoor_airflow_rate(space) / space.floorArea)
         else
-          spi.setAirChangesperHour(0.01) # Abitrary ACH
+          spi.setAirChangesperHour(0.01)
         end
-        target_ach = spi.getAirChangesPerHour(space.floorArea(), space.exteriorArea(), space.exteriorWallArea(), space.volume())
-        OpenStudio.logFree(
-          OpenStudio::Info, 'openstudio.179D.Model',
-          "Adding Design Day Only Infiltration for Space '#{space.nameString}' with equivalent #{target_ach.round(2)} ACH to avoid sizing errors"
-        )
+      end
+    end
+
+    return true unless add_cooling_exhaust
+
+    exterior_zone_data = zone_data_by_handle.values.select { |data| data[:has_exterior_connection] }
+    interior_zone_data = zone_data_by_handle.values.reject { |data| data[:has_exterior_connection] }
+    exterior_zones = exterior_zone_data.map { |data| data[:zone] }
+    source_zone_mixing_flow_m3_per_s = Hash.new(0.0)
+
+    interior_zone_data.each do |data|
+      interior_zone = data[:zone]
+      source_zone = _find_exterior_source_zone_for_interior_zone(interior_zone, exterior_zones)
+      next if source_zone.nil?
+
+      mixing_name = "#{interior_zone.name} Exterior Storage Mixing"
+      next if model.getZoneMixings.any? { |mixing| mixing.nameString == mixing_name }
+
+      mixing = OpenStudio::Model::ZoneMixing.new(interior_zone)
+      mixing.setName(mixing_name)
+      mixing.setSchedule(model.alwaysOnDiscreteSchedule)
+      mixing.setSourceZone(source_zone)
+      mixing_flow_m3_per_s = data[:base_cooling_flow_m3_per_s] * mixing_flow_fraction
+      mixing.setDesignFlowRate(mixing_flow_m3_per_s)
+      source_zone_mixing_flow_m3_per_s[source_zone.handle.to_s] += mixing_flow_m3_per_s
+    end
+
+    source_zone_mixing_flow_m3_per_s.each do |source_handle, total_mixing_flow_m3_per_s|
+      next unless total_mixing_flow_m3_per_s > 0.0
+
+      source_zone = zone_data_by_handle[source_handle][:zone]
+      intake_name = "#{source_zone.name} Mixing Makeup Air Intake"
+      mixing_makeup_intake = source_zone.equipment.filter_map do |eq|
+        zv = eq.to_ZoneVentilationDesignFlowRate
+        zv.get if zv.is_initialized && zv.get.nameString == intake_name
+      end.first
+
+      if mixing_makeup_intake.nil?
+        mixing_makeup_intake = OpenStudio::Model::ZoneVentilationDesignFlowRate.new(model)
+        mixing_makeup_intake.setName(intake_name)
+        mixing_makeup_intake.setSchedule(model.alwaysOnDiscreteSchedule)
+        mixing_makeup_intake.setConstantTermCoefficient(1.0)
+        mixing_makeup_intake.setVelocityTermCoefficient(0.0)
+        mixing_makeup_intake.setTemperatureTermCoefficient(0.0)
+        mixing_makeup_intake.setMinimumIndoorTemperature(-73.3333352760033)
+        mixing_makeup_intake.setMaximumIndoorTemperature(100.0)
+        mixing_makeup_intake.setDeltaTemperature(-100.0)
+        mixing_makeup_intake.setMinimumOutdoorTemperature(-100.0)
+        mixing_makeup_intake.setMaximumOutdoorTemperature(100.0)
+        mixing_makeup_intake.setVentilationType('Intake')
+        mixing_makeup_intake.setFanPressureRise(0.0)
+        mixing_makeup_intake.setFanTotalEfficiency(1.0)
+        mixing_makeup_intake.addToThermalZone(source_zone)
+        source_zone.setHeatingPriority(mixing_makeup_intake, 0)
+        source_zone.setCoolingPriority(mixing_makeup_intake, 0)
+      end
+
+      mixing_makeup_intake.setDesignFlowRate(total_mixing_flow_m3_per_s)
+    end
+  end
+
+  # Add Design-Day-Only SpaceInfiltrationDesignFlowRate to spaces in the given
+  # zones whose final infiltration ACH is < 0.001. Intended to be called AFTER
+  # space_type_apply_standard_infiltration has re-applied space-type-level
+  # infiltration (so space.infiltrationDesignAirChangesPerHour reflects the
+  # final value). Schedule has value 1 only on design days, 0 in 8760 — so
+  # this affects sizing convergence without changing annual results.
+  #
+  # @param model [OpenStudio::Model::Model]
+  # @param zones [Array<OpenStudio::Model::ThermalZone>] zones whose spaces to consider
+  def model_add_ddy_only_infiltration_for_heated_only_zones(model, zones)
+    zones.sort.each do |zone|
+      zone.spaces.each do |space|
+        next if space.infiltrationDesignAirChangesPerHour > 0.001
+
+        spi = OpenStudio::Model::SpaceInfiltrationDesignFlowRate.new(model)
+        spi.setName("#{space.nameString} Design Day Only Infiltration")
+        spi.setSpace(space)
+        spi.setSchedule(_get_or_create_ddy_only_infiltration_schedule(model))
+        if space.designSpecificationOutdoorAir.is_initialized
+          spi.setFlowperSpaceFloorArea(space_get_outdoor_airflow_rate(space) / space.floorArea)
+        else
+          spi.setAirChangesperHour(0.01)
+        end
       end
     end
   end

--- a/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.Model.rb
+++ b/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2007/179d_ashrae_90_1_2007/179d_ashrae_90_1_2007.Model.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ClassLength
 class ACM179dASHRAE9012007
   def __model_get_primary_building_type(model)
     building_types = {}
@@ -91,17 +92,15 @@ class ACM179dASHRAE9012007
     floor_area_sqft = OpenStudio.convert(floor_area, 'm^2', 'ft^2').get
     num_floors = model.getBuilding.buildingStories.size
     if floor_area_sqft < 25_000
-      if num_floors <= 3
-        return 'SmallOffice'
-      else
-        return 'MediumOffice'
-      end
+      return 'SmallOffice' if num_floors <= 3
+
+      return 'MediumOffice'
+
     elsif floor_area_sqft < 150_000
-      if num_floors <= 5
-        return 'MediumOffice'
-      else
-        return 'LargeOffice'
-      end
+      return 'MediumOffice' if num_floors <= 5
+
+      return 'LargeOffice'
+
     else
       return 'LargeOffice'
     end
@@ -109,7 +108,7 @@ class ACM179dASHRAE9012007
 
   # Patched to prefer the space area method above instead of just relying on
   # Building object
-  def model_get_building_properties(model, remap_office = true)
+  def model_get_building_properties(model, remap_office: true)
     # get climate zone from model
     climate_zone = OpenstudioStandards::Weather.model_get_climate_zone(model)
 
@@ -267,6 +266,7 @@ class ACM179dASHRAE9012007
     ventilation_zvs = model.getZoneVentilationDesignFlowRates.select do |zv|
       next false unless zv.nameString.end_with?(' Ventilation')
       next false unless zv.thermalZone.is_initialized
+
       zv.thermalZone.get.airLoopHVAC.empty?
     end
     unless ventilation_zvs.empty?
@@ -308,9 +308,11 @@ class ACM179dASHRAE9012007
   # @param sizing_run_dir [String] the directory where the sizing runs will be performed
   # @param debug [Boolean] if true, will report out more detailed debugging output
   # @param baseline_179d [Boolean] NOTE: 179D addition, True for the baseline, false for the proposed
+  # rubocop:disable Metrics/ParameterLists, Style/OptionalBooleanParameter
   def model_create_prm_baseline_building(model, building_type, climate_zone, custom = nil, sizing_run_dir = Dir.pwd, debug = false, baseline_179d = true, unmet_load_hours_check = false)
     model_create_prm_any_baseline_building(model, building_type, climate_zone, 'All others', 'All others', 'All others', false, false, custom, sizing_run_dir, false, unmet_load_hours_check, debug, baseline_179d)
   end
+  # rubocop:enable Metrics/ParameterLists, Style/OptionalBooleanParameter
 
   # Creates a Performance Rating Method (aka Appendix G aka LEED) baseline building model
   # based on the inputs currently in the model.
@@ -330,6 +332,7 @@ class ACM179dASHRAE9012007
   # @param run_all_orients [Boolean] indicate weather a baseline model should be created for all 4 orientations: same as user model, +90 deg, +180 deg, +270 deg
   # @param debug [Boolean] If true, will report out more detailed debugging output
   # @return [Boolean] returns true if successful, false if not
+  # rubocop:disable Metrics/AbcSize, Metrics/BlockLength, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/ParameterLists, Metrics/PerceivedComplexity, Style/OptionalBooleanParameter
   def model_create_prm_any_baseline_building(user_model, building_type, climate_zone, hvac_building_type = 'All others', wwr_building_type = 'All others', swh_building_type = 'All others', model_deep_copy = false, create_proposed_model = false, custom = nil, sizing_run_dir = Dir.pwd, run_all_orients = false, unmet_load_hours_check = true, debug = false, baseline_179d = true)
     args = {
       # "user_model"   => user_model,
@@ -345,7 +348,7 @@ class ACM179dASHRAE9012007
       'run_all_orients' => run_all_orients,
       'unmet_load_hours_check' => unmet_load_hours_check,
       'debug' => debug,
-      'baseline_179d' => baseline_179d,
+      'baseline_179d' => baseline_179d
     }
     if debug
       args.each { |k, v| OpenStudio.logFree(OpenStudio::Info, 'openstudio.prm.179d', "179d - model_create_prm_any_baseline_building inputs: #{k} - #{v}") }
@@ -424,6 +427,7 @@ class ACM179dASHRAE9012007
       proposed_model.getSpaces.sort.each do |space|
         space_cond_type = space_conditioning_category(space)
         next if space_cond_type == 'Unconditioned'
+
         OpenStudioStandards::RulesetChecking.tag_spaces(idf, space)
       end
       idf_path = OpenStudio::Path.new("#{sizing_run_dir}/proposed_final.idf")
@@ -566,7 +570,6 @@ class ACM179dASHRAE9012007
           lights.setSchedule(model.alwaysOffDiscreteSchedule)
         end
       end
-
 
       # Run a sizing run to calculate VLT for layer-by-layer windows.
       # TODO check if not required for 90.1-2007 full appendix (only required for 90.1-2010)
@@ -723,13 +726,13 @@ class ACM179dASHRAE9012007
                                         zone_fan_scheds)
 
           if baseline_179d && ['Gas_Furnace', 'Electric_Furnace'].include?(system_type[0])
-            OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.Model', "179D - For Unit Heater, adding a ZoneVentilationDesignFlowRate for outside air requirements")
+            OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.Model', '179D - For Unit Heater, adding ZoneVentilationDesignFlowRate objects for ventilation and cooling exhaust')
             model_add_equivalent_zone_ventilation_for_heated_only_zones_with_dsoa(
               model,
               sys_group['zones'],
               ventilation_type: 'Exhaust',
               ensure_ddy_infiltration: true,
-              add_cooling_exhaust: building_type == 'Warehouse',
+              add_cooling_exhaust: building_type == 'Warehouse'
             )
           end
 
@@ -767,7 +770,7 @@ class ACM179dASHRAE9012007
         end
       end
 
-      unless (['PrimarySchool', 'SecondarySchool'].include?(building_type) && !baseline_179d)
+      unless ['PrimarySchool', 'SecondarySchool'].include?(building_type) && !baseline_179d
         OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.Model', '*** Applying Baseline HVAC System Sizing Settings ***')
         model.getThermalZones.each do |zone|
           thermal_zone_apply_prm_baseline_supply_temperatures(zone)
@@ -823,13 +826,14 @@ class ACM179dASHRAE9012007
         OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.Model', '*** Baseline Adjust Minimum/Design Outdoor Air Flow Rate to Proposed Levels if different ***')
         total_oa_design_flow_rate = 0.0
 
-        # Get minimum and design outdoor airflow rates
+        # Get total design outdoor airflow rates using the same accounting scope
+        # as reporting_179_d (air-loop + zone-level contributors).
         outdoor_airflow_rate_baseline_m_3_per_s = get_minimum_and_design_outdoor_airflow_rates(model, 'BASELINE')
 
         # Calculate % difference (relative to baseline)
         pct_diff_minimum_outdoor_airflow_rate =
-          if outdoor_airflow_rate_baseline_m_3_per_s == 0.0
-            outdoor_airflow_rate_proposed_m_3_per_s == 0.0 ? 0.0 : 100.0
+          if outdoor_airflow_rate_baseline_m_3_per_s.zero?
+            outdoor_airflow_rate_proposed_m_3_per_s.zero? ? 0.0 : 100.0
           else
             (
               outdoor_airflow_rate_proposed_m_3_per_s - outdoor_airflow_rate_baseline_m_3_per_s
@@ -840,28 +844,59 @@ class ACM179dASHRAE9012007
         diff_threshold_pcnt = 1.0
 
         # Adjust design outdoor airflow rate if difference between baseline/proposed is larger than 1%
-        if pct_diff_minimum_outdoor_airflow_rate.abs > diff_threshold_pcnt # %
-          msg = "BASELINE: Minimum/Design outdoor airflow rate for the baseline model is " \
-                "#{outdoor_airflow_rate_baseline_m_3_per_s.round(2)} m3/s, " \
-                "which is more than #{diff_threshold_pcnt}% different from the proposed model's minimum/design outdoor airflow rate of " \
-                "#{outdoor_airflow_rate_proposed_m_3_per_s.round(2)} m3/s. " \
-                "Adjusting baseline model design outdoor airflow rate to match the proposed model's design outdoor airflow rate."
-          OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.Model', msg)
+        if outdoor_airflow_rate_baseline_m_3_per_s < -1.0e-9
+          msg = 'BASELINE: Cannot proportionally adjust outdoor airflow rate because baseline total OA is negative.'
+          OpenStudio.logFree(OpenStudio::Error, 'openstudio.standards.Model', msg)
+          raise msg
+        end
 
-          # Proportionally adjust design outdoor airflow rate
-          scaling_factor = outdoor_airflow_rate_proposed_m_3_per_s / outdoor_airflow_rate_baseline_m_3_per_s
-          model.getAirLoopHVACs.sort.each do |air_loop|
-            sizing_system = air_loop.sizingSystem
-            old_value = nil
-            if sizing_system.designOutdoorAirFlowRate.is_initialized
-              old_value = sizing_system.designOutdoorAirFlowRate.get
-            elsif sizing_system.autosizedDesignOutdoorAirFlowRate.is_initialized
-              old_value = sizing_system.autosizedDesignOutdoorAirFlowRate.get
+        if pct_diff_minimum_outdoor_airflow_rate.abs > diff_threshold_pcnt # %
+          if outdoor_airflow_rate_baseline_m_3_per_s.abs <= 1.0e-9
+            msg = 'BASELINE: Cannot proportionally adjust outdoor airflow rate because baseline total OA is zero. Skipping OA scaling.'
+            OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.Model', msg)
+          else
+            msg = 'BASELINE: Minimum/Design outdoor airflow rate for the baseline model is ' \
+                  "#{outdoor_airflow_rate_baseline_m_3_per_s.round(2)} m3/s, " \
+                  "which is more than #{diff_threshold_pcnt}% different from the proposed model's minimum/design outdoor airflow rate of " \
+                  "#{outdoor_airflow_rate_proposed_m_3_per_s.round(2)} m3/s. " \
+                  "Adjusting baseline model design outdoor airflow rate to match the proposed model's design outdoor airflow rate."
+            OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.Model', msg)
+
+            # Proportionally adjust design outdoor airflow rates to preserve
+            # per-system/per-zone distributions while matching proposed total OA.
+            scaling_factor = outdoor_airflow_rate_proposed_m_3_per_s / outdoor_airflow_rate_baseline_m_3_per_s
+            model.getAirLoopHVACs.sort.each do |air_loop|
+              sizing_system = air_loop.sizingSystem
+              old_value = nil
+              if sizing_system.designOutdoorAirFlowRate.is_initialized
+                old_value = sizing_system.designOutdoorAirFlowRate.get
+              elsif sizing_system.autosizedDesignOutdoorAirFlowRate.is_initialized
+                old_value = sizing_system.autosizedDesignOutdoorAirFlowRate.get
+              end
+              if old_value
+                sizing_system.setDesignOutdoorAirFlowRate(old_value * scaling_factor)
+              else
+                msg = "BASELINE: Cannot adjust design outdoor airflow rate — no existing value found on air loop '#{air_loop.nameString}'."
+                OpenStudio.logFree(OpenStudio::Error, 'openstudio.standards.Model', msg)
+                raise msg
+              end
             end
-            if old_value
-              sizing_system.setDesignOutdoorAirFlowRate(old_value * scaling_factor)
-            else
-              msg = "BASELINE: Cannot adjust design outdoor airflow rate — no existing value found on air loop '#{air_loop.nameString}'."
+
+            scale_zone_level_outdoor_airflow_rates(model, scaling_factor)
+
+            # Re-evaluate post-adjustment OA to ensure scaling converged.
+            adjusted_baseline_oa_m_3_per_s = get_minimum_and_design_outdoor_airflow_rates(model, 'BASELINE (POST SCALE)')
+            post_pct_diff =
+              if adjusted_baseline_oa_m_3_per_s.zero?
+                outdoor_airflow_rate_proposed_m_3_per_s.zero? ? 0.0 : 100.0
+              else
+                (
+                  outdoor_airflow_rate_proposed_m_3_per_s - adjusted_baseline_oa_m_3_per_s
+                ) / adjusted_baseline_oa_m_3_per_s * 100.0
+              end
+            if post_pct_diff.abs > diff_threshold_pcnt
+              msg = 'BASELINE: Total design outdoor airflow rate remains outside threshold after scaling ' \
+                    "(#{post_pct_diff.round(2)}% difference; threshold=#{diff_threshold_pcnt}%)."
               OpenStudio.logFree(OpenStudio::Error, 'openstudio.standards.Model', msg)
               raise msg
             end
@@ -890,6 +925,7 @@ class ACM179dASHRAE9012007
 
       # Set the baseline number of cooling towers
       # Must be done after all chillers are added
+      # rubocop:disable Style/CombinableLoops
       model.getPlantLoops.sort.each do |plant_loop|
         # Skip the SWH loops
         next if plant_loop_swh_loop?(plant_loop)
@@ -898,6 +934,7 @@ class ACM179dASHRAE9012007
           plant_loop_apply_prm_number_of_cooling_towers(plant_loop)
         end
       end
+      # rubocop:enable Style/CombinableLoops
 
       # Run sizing run with the new chillers, boilers, and cooling towers to determine capacities
       if model_run_sizing_run(model, "#{sizing_run_dir}/SR2") == false
@@ -961,11 +998,12 @@ class ACM179dASHRAE9012007
       model.getSpaces.sort.each do |space|
         space_cond_type = space_conditioning_category(space)
         next if space_cond_type == 'Unconditioned'
+
         OpenStudioStandards::RulesetChecking.tag_spaces(idf, space)
       end
       idf_path = OpenStudio::Path.new("#{sizing_run_dir}/#{model_status}.idf")
       idf.save(idf_path, true)
-      OpenStudioStandards::RulesetChecking.export_epjson(model, sizing_run_dir, "#{model_status}")
+      OpenStudioStandards::RulesetChecking.export_epjson(model, sizing_run_dir, model_status.to_s)
 
       prm_system_type_str = prm_system_types.uniq.map { |x| x[0] }.uniq.join('***')
       model.getBuilding.additionalProperties.setFeature('prm_baseline_system_type', prm_system_type_str)
@@ -979,7 +1017,7 @@ class ACM179dASHRAE9012007
         # Original
         # get_sizing_factor_multiplier = lambda {|unmet_hours| unmet_hours > 150 ? 1.1 : 1.05 }
         # New, more aggressive
-        get_sizing_factor_multiplier = lambda { |unmet_hours| 1.025 + unmet_hours * 0.0005 }
+        get_sizing_factor_multiplier = ->(unmet_hours) { 1.025 + (unmet_hours * 0.0005) }
 
         loop do
           OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.Model', "Starting the pre-simulation for the #{nb_adjustments + 1} round of zone sizing factor adjustments for the unmet load hours for the baseline model (#{degs} degree of rotation)")
@@ -1070,15 +1108,16 @@ class ACM179dASHRAE9012007
 
     return true
   end
+  # rubocop:enable Metrics/AbcSize, Metrics/BlockLength, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/ParameterLists, Metrics/PerceivedComplexity, Style/OptionalBooleanParameter
 
   def _get_or_create_ddy_only_infiltration_schedule(model)
-    ddy_only_infil_sch_name = "Infiltration Schedule Only One on Design Days"
+    ddy_only_infil_sch_name = 'Infiltration Schedule Only One on Design Days'
     sch_ = model.getScheduleRulesetByName(ddy_only_infil_sch_name)
     return sch_.get if sch_.is_initialized
 
     sch_ruleset = OpenStudio::Model::ScheduleRuleset.new(model, 0.0)
     sch_ruleset.setName(ddy_only_infil_sch_name)
-    sch_ruleset.defaultDaySchedule().setName("#{ddy_only_infil_sch_name} Default Day")
+    sch_ruleset.defaultDaySchedule.setName("#{ddy_only_infil_sch_name} Default Day")
 
     # Winter Design Day
     temp = OpenStudio::Model::ScheduleDay.new(model)
@@ -1099,17 +1138,16 @@ class ACM179dASHRAE9012007
 
   def space_get_outdoor_airflow_rate(space)
     return 0.0 if space.designSpecificationOutdoorAir.empty?
+
     dsoa = space.designSpecificationOutdoorAir.get
     oa_people = space.numberOfPeople * dsoa.outdoorAirFlowperPerson
     oa_floor_area = space.floorArea * dsoa.outdoorAirFlowperFloorArea
     oa_rate = dsoa.outdoorAirFlowRate
     oa_volume = space.volume * dsoa.outdoorAirFlowAirChangesperHour / 3600.0
 
-    if dsoa.outdoorAirMethod.downcase == 'sum'
-      return [oa_people, oa_floor_area, oa_rate, oa_volume].sum
-    else
-      return [oa_people, oa_floor_area, oa_rate, oa_volume].max
-    end
+    return [oa_people, oa_floor_area, oa_rate, oa_volume].sum if dsoa.outdoorAirMethod.casecmp('sum').zero?
+
+    return [oa_people, oa_floor_area, oa_rate, oa_volume].max
   end
 
   def _zone_has_exterior_connection?(zone, minimum_exterior_area_m2: 0.001)
@@ -1208,6 +1246,7 @@ class ACM179dASHRAE9012007
   #   on interior-zone always-on mixing flow. If nil, this can be calibrated via
   #   building additional property `179d_interior_zone_mixing_flow_fraction`.
   #   Defaults to 1.0 if not provided.
+  # rubocop:disable Metrics/AbcSize, Metrics/BlockLength
   def model_add_equivalent_zone_ventilation_for_heated_only_zones_with_dsoa(
     model, zones,
     ventilation_type: 'Natural',
@@ -1217,18 +1256,24 @@ class ACM179dASHRAE9012007
     cooling_exhaust_delta_t_c: 2.0,
     interior_zone_mixing_flow_fraction: nil
   )
+    # Default cooling exhaust flow rate: ASHRAE heat-balance approach,
+    # ~4.4 BTU/hr/ft² internal gains at 15°F (8.3°C) permissible ΔT → ~0.27 CFM/ft²
+    # Reference: ASHRAE Handbook of Fundamentals, Chapter 16.
     cooling_flow_m3_per_s_per_m2 = cooling_exhaust_flow_per_area_m3_per_s_per_m2 ||
                                    OpenStudio.convert(0.27, 'CFM/ft^2', 'm^3/s*m^2').get
 
+    # Fan power parameters (same for both ventilation and cooling exhaust objects)
     case ventilation_type
     when 'Natural'
       pressure_rise_pa = 0.0
       fan_total_eff = 1.0
     when 'Intake'
+      # System 9 and 10 supply fan: Pfan = CFM × 0.3 W/CFM
       target_w_per_m3_per_s = OpenStudio.convert(0.3, 'W/CFM', 'W*s/m^3').get
       fan_total_eff = 0.6
       pressure_rise_pa = fan_total_eff * target_w_per_m3_per_s
     when 'Exhaust'
+      # System 9 and 10 non-mechanical cooling fan per §G3.1.2.8.2: Pfan = CFM × 0.054 W/CFM
       target_w_per_m3_per_s = OpenStudio.convert(0.054, 'W/CFM', 'W*s/m^3').get
       fan_total_eff = 0.6
       pressure_rise_pa = fan_total_eff * target_w_per_m3_per_s
@@ -1236,6 +1281,10 @@ class ACM179dASHRAE9012007
       raise "ventilation_type must be one of ['Natural', 'Intake', 'Exhaust']"
     end
 
+    # Resolve the occupied schedule once for all zones.
+    # Prefer the ACM schedule stored in building additional properties by get_fan_schedule_for_each_zone
+    # (which runs before ZV creation in model_create_prm_baseline_building). Fall back to a standards
+    # data lookup, then to always-on.
     occupied_sched = nil
     acm_sch_name_opt = model.getBuilding.additionalProperties.getFeatureAsString('acm_fan_sch')
     if acm_sch_name_opt.is_initialized
@@ -1258,6 +1307,9 @@ class ACM179dASHRAE9012007
     end
     raise 'interior_zone_mixing_flow_fraction must be >= 0.0' if mixing_flow_fraction < 0.0
 
+    # If cooling exhaust is limited to interior zones, renormalize its per-area
+    # flow so the *total* cooling exhaust capacity still reflects the entire
+    # heated-only storage area served by this routine.
     eligible_zone_total_floor_area_m2 = 0.0
     eligible_interior_zone_total_floor_area_m2 = 0.0
     eligible_exterior_zone_total_floor_area_m2 = 0.0
@@ -1283,16 +1335,30 @@ class ACM179dASHRAE9012007
     if add_cooling_exhaust
       if eligible_interior_zone_total_floor_area_m2 > 0.0
         interior_cooling_exhaust_flow_m3_per_s_per_m2 = cooling_flow_m3_per_s_per_m2 *
-                                                         (eligible_zone_total_floor_area_m2 / eligible_interior_zone_total_floor_area_m2)
+                                                        (eligible_zone_total_floor_area_m2 / eligible_interior_zone_total_floor_area_m2)
+        OpenStudio.logFree(
+          OpenStudio::Info, 'openstudio.179D.Model',
+          "Renormalizing interior cooling exhaust flow from #{OpenStudio.convert(cooling_flow_m3_per_s_per_m2, 'm^3/s*m^2', 'CFM/ft^2').get.round(4)} to #{OpenStudio.convert(interior_cooling_exhaust_flow_m3_per_s_per_m2, 'm^3/s*m^2', 'CFM/ft^2').get.round(4)} CFM/ft^2 using area ratio #{(eligible_zone_total_floor_area_m2 / eligible_interior_zone_total_floor_area_m2).round(4)}"
+        )
       else
-        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.179D.Model', 'No interior heated-only zones found for cooling exhaust renormalization; using default cooling exhaust flow.')
+        OpenStudio.logFree(
+          OpenStudio::Warn, 'openstudio.179D.Model',
+          'No interior heated-only zones found for cooling exhaust renormalization; using default cooling exhaust flow.'
+        )
       end
 
       if eligible_exterior_zone_total_floor_area_m2 > 0.0
         exterior_cooling_makeup_flow_m3_per_s_per_m2 = cooling_flow_m3_per_s_per_m2 *
-                                                        (eligible_zone_total_floor_area_m2 / eligible_exterior_zone_total_floor_area_m2)
+                                                       (eligible_zone_total_floor_area_m2 / eligible_exterior_zone_total_floor_area_m2)
+        OpenStudio.logFree(
+          OpenStudio::Info, 'openstudio.179D.Model',
+          "Renormalizing exterior cooling make-up intake flow from #{OpenStudio.convert(cooling_flow_m3_per_s_per_m2, 'm^3/s*m^2', 'CFM/ft^2').get.round(4)} to #{OpenStudio.convert(exterior_cooling_makeup_flow_m3_per_s_per_m2, 'm^3/s*m^2', 'CFM/ft^2').get.round(4)} CFM/ft^2 using area ratio #{(eligible_zone_total_floor_area_m2 / eligible_exterior_zone_total_floor_area_m2).round(4)}"
+        )
       else
-        OpenStudio.logFree(OpenStudio::Warn, 'openstudio.179D.Model', 'No exterior heated-only zones found for cooling make-up intake renormalization; using default cooling make-up intake flow.')
+        OpenStudio.logFree(
+          OpenStudio::Warn, 'openstudio.179D.Model',
+          'No exterior heated-only zones found for cooling make-up intake renormalization; using default cooling make-up intake flow.'
+        )
       end
     end
 
@@ -1308,12 +1374,25 @@ class ACM179dASHRAE9012007
       total_oa_m3_per_m2s = total_oa_m3_per_s / zone.floorArea
       next unless total_oa_m3_per_s > 0
 
+      tot_oa_cfm = OpenStudio.convert(total_oa_m3_per_s, 'm^3/s', 'cfm').get.round(2)
+      total_oa_cfm_per_sqft = OpenStudio.convert(total_oa_m3_per_m2s, 'm^3/m^2*s', 'cfm/ft^2').get.round(4)
+
+      OpenStudio.logFree(
+        OpenStudio::Info, 'openstudio.179D.Model',
+        "Adding ventilation exhaust for #{zone.name} - #{tot_oa_cfm} CFM total - #{total_oa_cfm_per_sqft} CFM/ft^2"
+      )
       zone_data_by_handle[zone.handle.to_s] = {
         zone: zone,
         has_exterior_connection: _zone_has_exterior_connection?(zone),
         base_cooling_flow_m3_per_s: cooling_flow_m3_per_s_per_m2 * zone.floorArea
       }
 
+      # ------------------------------------------------------------------
+      # System 1: Year-round occupied exhaust for code-required ventilation
+      # Runs on the zone HVAC availability schedule (occupied hours only).
+      # Temperature limits are permissive — this provides IAQ-required OA
+      # through infiltration makeup regardless of indoor/outdoor conditions.
+      # ------------------------------------------------------------------
       ventilation = OpenStudio::Model::ZoneVentilationDesignFlowRate.new(model)
       ventilation.setName("#{zone.name} Ventilation")
       ventilation.setSchedule(occupied_sched || model.alwaysOnDiscreteSchedule)
@@ -1332,6 +1411,16 @@ class ACM179dASHRAE9012007
       zone.setCoolingPriority(ventilation, 0)
 
       if add_cooling_exhaust
+        # ------------------------------------------------------------------
+        # System 2: Cooling airflow for summer overheating prevention.
+        # Sized using ASHRAE heat-balance approach (~0.27 CFM/ft²).
+        # Activates only when:
+        #   (a) indoor temp > thermostat cooling setpoint (free-cooling trigger)
+        #   (b) indoor temp exceeds outdoor temp by at least delta_t (free cooling)
+        #   (c) outdoor temp >= 13°C (55°F) — prevents operation in cold weather
+        # ------------------------------------------------------------------
+        cooling_makeup_cfm_per_sqft = OpenStudio.convert(exterior_cooling_makeup_flow_m3_per_s_per_m2, 'm^3/s*m^2', 'CFM/ft^2').get.round(4)
+        interior_cooling_exhaust_cfm_per_sqft = OpenStudio.convert(interior_cooling_exhaust_flow_m3_per_s_per_m2, 'm^3/s*m^2', 'CFM/ft^2').get.round(4)
         zone_data = zone_data_by_handle[zone.handle.to_s]
         if zone_data[:has_exterior_connection]
           intake_name = "#{zone.name} Cooling Makeup Air Intake"
@@ -1340,6 +1429,10 @@ class ACM179dASHRAE9012007
             zv.get if zv.is_initialized && zv.get.nameString == intake_name
           end.first
           if cooling_makeup_intake.nil?
+            OpenStudio.logFree(
+              OpenStudio::Info, 'openstudio.179D.Model',
+              "Adding cooling make-up intake for #{zone.name} - #{cooling_makeup_cfm_per_sqft} CFM/ft^2"
+            )
             cooling_makeup_intake = OpenStudio::Model::ZoneVentilationDesignFlowRate.new(model)
             cooling_makeup_intake.setName(intake_name)
             cooling_makeup_intake.setSchedule(model.alwaysOnDiscreteSchedule)
@@ -1349,6 +1442,7 @@ class ACM179dASHRAE9012007
             cooling_makeup_intake.setTemperatureTermCoefficient(0.0)
             _apply_cooling_exhaust_gate_to_zone_ventilation(cooling_makeup_intake, zone, cooling_exhaust_delta_t_c: cooling_exhaust_delta_t_c)
             cooling_makeup_intake.setVentilationType('Intake')
+            # Gravity-damper analog: no dedicated intake fan power.
             cooling_makeup_intake.setFanPressureRise(0.0)
             cooling_makeup_intake.setFanTotalEfficiency(1.0)
             cooling_makeup_intake.addToThermalZone(zone)
@@ -1362,6 +1456,11 @@ class ACM179dASHRAE9012007
             zv.is_initialized && zv.get.nameString == cooling_exhaust_name
           end
           unless has_cooling_exhaust
+            OpenStudio.logFree(
+              OpenStudio::Info, 'openstudio.179D.Model',
+              "Adding cooling exhaust for #{zone.name} - #{interior_cooling_exhaust_cfm_per_sqft} CFM/ft^2 - delta_t=#{cooling_exhaust_delta_t_c}°C"
+            )
+
             cooling_exhaust = OpenStudio::Model::ZoneVentilationDesignFlowRate.new(model)
             cooling_exhaust.setName(cooling_exhaust_name)
             cooling_exhaust.setSchedule(model.alwaysOnDiscreteSchedule)
@@ -1384,6 +1483,7 @@ class ACM179dASHRAE9012007
 
       zone.spaces.each do |space|
         next if space.infiltrationDesignAirChangesPerHour > 0.001
+
         spi = OpenStudio::Model::SpaceInfiltrationDesignFlowRate.new(model)
         spi.setName("#{space.nameString} Design Day Only Infiltration")
         spi.setSpace(space)
@@ -1393,18 +1493,23 @@ class ACM179dASHRAE9012007
         else
           spi.setAirChangesperHour(0.01)
         end
+        target_ach = spi.getAirChangesPerHour(space.floorArea, space.exteriorArea, space.exteriorWallArea, space.volume)
+        OpenStudio.logFree(
+          OpenStudio::Info, 'openstudio.179D.Model',
+          "Adding Design Day Only Infiltration for Space '#{space.nameString}' with equivalent #{target_ach.round(2)} ACH to avoid sizing errors"
+        )
       end
     end
 
     return true unless add_cooling_exhaust
 
-    exterior_zone_data = zone_data_by_handle.values.select { |data| data[:has_exterior_connection] }
-    interior_zone_data = zone_data_by_handle.values.reject { |data| data[:has_exterior_connection] }
-    exterior_zones = exterior_zone_data.map { |data| data[:zone] }
+    exterior_zone_data = zone_data_by_handle.values.select { |zd| zd[:has_exterior_connection] }
+    interior_zone_data = zone_data_by_handle.values.reject { |zd| zd[:has_exterior_connection] }
+    exterior_zones = exterior_zone_data.map { |zd| zd[:zone] }
     source_zone_mixing_flow_m3_per_s = Hash.new(0.0)
 
-    interior_zone_data.each do |data|
-      interior_zone = data[:zone]
+    interior_zone_data.each do |zd|
+      interior_zone = zd[:zone]
       source_zone = _find_exterior_source_zone_for_interior_zone(interior_zone, exterior_zones)
       next if source_zone.nil?
 
@@ -1413,11 +1518,17 @@ class ACM179dASHRAE9012007
 
       mixing = OpenStudio::Model::ZoneMixing.new(interior_zone)
       mixing.setName(mixing_name)
+      # Air-wall-separated storage spaces continuously exchange air in operation.
       mixing.setSchedule(model.alwaysOnDiscreteSchedule)
       mixing.setSourceZone(source_zone)
-      mixing_flow_m3_per_s = data[:base_cooling_flow_m3_per_s] * mixing_flow_fraction
+      # Use base (pre-renormalization) cooling flow for interior/exterior transfer via mixing.
+      mixing_flow_m3_per_s = zd[:base_cooling_flow_m3_per_s] * mixing_flow_fraction
       mixing.setDesignFlowRate(mixing_flow_m3_per_s)
       source_zone_mixing_flow_m3_per_s[source_zone.handle.to_s] += mixing_flow_m3_per_s
+      OpenStudio.logFree(
+        OpenStudio::Info, 'openstudio.179D.Model',
+        "Adding always-on exterior/interior zone mixing from '#{source_zone.name}' to '#{interior_zone.name}' at #{OpenStudio.convert(mixing_flow_m3_per_s, 'm^3/s', 'cfm').get.round(2)} CFM (fraction=#{mixing_flow_fraction})"
+      )
     end
 
     source_zone_mixing_flow_m3_per_s.each do |source_handle, total_mixing_flow_m3_per_s|
@@ -1443,6 +1554,7 @@ class ACM179dASHRAE9012007
         mixing_makeup_intake.setMinimumOutdoorTemperature(-100.0)
         mixing_makeup_intake.setMaximumOutdoorTemperature(100.0)
         mixing_makeup_intake.setVentilationType('Intake')
+        # Gravity-damper analog: no dedicated intake fan power.
         mixing_makeup_intake.setFanPressureRise(0.0)
         mixing_makeup_intake.setFanTotalEfficiency(1.0)
         mixing_makeup_intake.addToThermalZone(source_zone)
@@ -1451,8 +1563,13 @@ class ACM179dASHRAE9012007
       end
 
       mixing_makeup_intake.setDesignFlowRate(total_mixing_flow_m3_per_s)
+      OpenStudio.logFree(
+        OpenStudio::Info, 'openstudio.179D.Model',
+        "Adding always-on mixing make-up intake for '#{source_zone.name}' at #{OpenStudio.convert(total_mixing_flow_m3_per_s, 'm^3/s', 'cfm').get.round(2)} CFM"
+      )
     end
   end
+  # rubocop:enable Metrics/AbcSize, Metrics/BlockLength
 
   # Add Design-Day-Only SpaceInfiltrationDesignFlowRate to spaces in the given
   # zones whose final infiltration ACH is < 0.001. Intended to be called AFTER
@@ -1477,6 +1594,11 @@ class ACM179dASHRAE9012007
         else
           spi.setAirChangesperHour(0.01)
         end
+        target_ach = spi.getAirChangesPerHour(space.floorArea, space.exteriorArea, space.exteriorWallArea, space.volume)
+        OpenStudio.logFree(
+          OpenStudio::Info, 'openstudio.179D.Model',
+          "Adding Design Day Only Infiltration for Space '#{space.nameString}' with equivalent #{target_ach.round(2)} ACH to avoid sizing errors"
+        )
       end
     end
   end
@@ -1502,14 +1624,15 @@ class ACM179dASHRAE9012007
     return fan_sch_names
   end
 
-  # get minimum outdoor airflow rate from Controller:OutdoorAir
-  # get design outdoor airflow rate from Sizing:System
-  # only considering airloop outdoor airflow rates
-  # and not considering packaged terminal outdoor airflow rates
+  # get total design outdoor airflow rate by summing:
+  # 1) air-loop outdoor airflow rates (Controller:OutdoorAir + Sizing:System context)
+  # 2) zone-level outdoor airflow contributors
+  # This matches the reporting_179_d accounting scope for
+  # in_hvac_controls_design_outdoor_air_supply_flow_total.
   # @param model [object]
-  # @return [array] of airflow rates: [outdoor_airflow_rate_minimum_m_3_per_s, outdoor_airflow_rate_design_m_3_per_s]
+  # @return [float] total design outdoor airflow rate [m3/s]
   def get_minimum_and_design_outdoor_airflow_rates(model, scenario)
-    minimum_design_outdoor_airflow_rate_m_3_per_s = 0.0
+    air_loop_outdoor_airflow_rate_m_3_per_s = 0.0
 
     model.getAirLoopHVACs.each do |air_loop|
       # Initialize values for this air loop
@@ -1531,32 +1654,198 @@ class ACM179dASHRAE9012007
       elsif controller_oa.autosizedMinimumOutdoorAirFlowRate.is_initialized
         value = controller_oa.autosizedMinimumOutdoorAirFlowRate.get
       else
-        # making it fail for now to test later
-        msg = "#{scenario}: Cannot get minimum/design outdoor airflow rate from air loop hvac '#{air_loop_hvac.nameString}'."
+        msg = "#{scenario}: Cannot get minimum/design outdoor airflow rate from air loop hvac '#{air_loop.nameString}'."
         OpenStudio.logFree(OpenStudio::Error, 'openstudio.standards.Model', msg)
         raise msg
       end
 
       # Use the maximum of the two values for this air loop
-      minimum_design_outdoor_airflow_rate_m_3_per_s += value
+      air_loop_outdoor_airflow_rate_m_3_per_s += value
       OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.Model', "#{scenario}: airloop = #{air_loop.nameString} | minimum/design outdoor airflow rate = #{value} m3/s")
     end
+
+    zone_level_outdoor_airflow_rate_m_3_per_s = get_zone_level_outdoor_airflow_rate(model)
+    total_outdoor_airflow_rate_m_3_per_s = air_loop_outdoor_airflow_rate_m_3_per_s + zone_level_outdoor_airflow_rate_m_3_per_s
 
     OpenStudio.logFree(
       OpenStudio::Info,
       'openstudio.standards.Model', "#{scenario}: minimum_design_outdoor_airflow_rate_m_3_per_s = #{minimum_design_outdoor_airflow_rate_m_3_per_s}"
     )
+    OpenStudio.logFree(
+      OpenStudio::Info,
+      'openstudio.standards.Model', "#{scenario}: zone_level_outdoor_airflow_rate_m_3_per_s = #{zone_level_outdoor_airflow_rate_m_3_per_s}"
+    )
+    OpenStudio.logFree(
+      OpenStudio::Info,
+      'openstudio.standards.Model', "#{scenario}: total_outdoor_airflow_rate_m_3_per_s = #{total_outdoor_airflow_rate_m_3_per_s}"
+    )
 
-    return minimum_design_outdoor_airflow_rate_m_3_per_s
+    return total_outdoor_airflow_rate_m_3_per_s
+  end
+
+  def zone_ventilation_design_flow_rate_m3_per_s(zone_ventilation)
+    return 0.0 unless zone_ventilation.thermalZone.is_initialized
+
+    zone = zone_ventilation.thermalZone.get
+    area = zone.floorArea
+    volume = zone.airVolume
+    people = zone.numberOfPeople
+    case zone_ventilation.designFlowRateCalculationMethod
+    when 'Flow/Area'
+      zone_ventilation.flowRateperZoneFloorArea.to_f * area
+    when 'Flow/Person'
+      zone_ventilation.flowRateperPerson.to_f * people
+    when 'AirChanges/Hour'
+      zone_ventilation.airChangesperHour.to_f * volume / 3600.0
+    when 'Flow/Zone'
+      zone_ventilation.designFlowRate.to_f
+    else
+      0.0
+    end
+  end
+
+  def get_zone_level_outdoor_airflow_rate(model)
+    outdoor_airflow_rate_m_3_per_s = 0.0
+    seen_zone_ventilation_signatures = {}
+    model.getThermalZones.sort.each do |zone|
+      zone.equipment.each do |zone_equipment|
+        handled = false
+        obj_types_to_check = [
+          :to_ZoneHVACPackagedTerminalAirConditioner,
+          :to_ZoneHVACPackagedTerminalHeatPump,
+          :to_ZoneHVACWaterToAirHeatPump,
+          :to_ZoneHVACFourPipeFanCoil,
+          :to_ZoneHVACTerminalUnitVariableRefrigerantFlow
+        ]
+        obj_types_to_check.each do |meth|
+          next unless zone_equipment.respond_to?(meth) && zone_equipment.send(meth).is_initialized
+
+          zone_hvac = zone_equipment.send(meth).get
+          oa_rate = if meth == :to_ZoneHVACFourPipeFanCoil
+                      zone_hvac.maximumOutdoorAirFlowRate
+                    else
+                      zone_hvac.outdoorAirFlowRateDuringCoolingOperation
+                    end
+
+          if oa_rate.is_initialized
+            outdoor_airflow_rate_m_3_per_s += oa_rate.get
+          elsif meth == :to_ZoneHVACFourPipeFanCoil &&
+                zone_hvac.respond_to?(:isMaximumOutdoorAirFlowRateAutosized) &&
+                zone_hvac.isMaximumOutdoorAirFlowRateAutosized &&
+                zone_hvac.respond_to?(:autosizedMaximumOutdoorAirFlowRate) &&
+                zone_hvac.autosizedMaximumOutdoorAirFlowRate.is_initialized
+            outdoor_airflow_rate_m_3_per_s += zone_hvac.autosizedMaximumOutdoorAirFlowRate.get
+          elsif zone_hvac.respond_to?(:autosizedCoolingOutdoorAirFlowRate) &&
+                zone_hvac.autosizedCoolingOutdoorAirFlowRate.is_initialized
+            outdoor_airflow_rate_m_3_per_s += zone_hvac.autosizedCoolingOutdoorAirFlowRate.get
+          end
+          handled = true
+          break
+        end
+
+        next if handled
+        next unless zone_equipment.to_ZoneVentilationDesignFlowRate.is_initialized
+
+        zone_ventilation = zone_equipment.to_ZoneVentilationDesignFlowRate.get
+        flow_rate = zone_ventilation_design_flow_rate_m3_per_s(zone_ventilation)
+        normalized_name = zone_ventilation.nameString.gsub(/\s+\d+$/, '')
+        signature = [
+          zone.handle.to_s,
+          normalized_name,
+          zone_ventilation.ventilationType,
+          zone_ventilation.designFlowRateCalculationMethod,
+          flow_rate.round(6)
+        ]
+        next if seen_zone_ventilation_signatures[signature]
+
+        seen_zone_ventilation_signatures[signature] = true
+        outdoor_airflow_rate_m_3_per_s += flow_rate
+      end
+    end
+    return outdoor_airflow_rate_m_3_per_s
+  end
+
+  def _scaled_value(object, value_method, autosized_method, scaling_factor)
+    if object.respond_to?(value_method)
+      value_optional = object.send(value_method)
+      return value_optional.get * scaling_factor if value_optional.is_initialized
+    end
+    if !autosized_method.nil? && object.respond_to?(autosized_method)
+      autosized_optional = object.send(autosized_method)
+      return autosized_optional.get * scaling_factor if autosized_optional.is_initialized
+    end
+
+    return nil
+  end
+
+  def scale_zone_ventilation_design_flow_rate(zone_ventilation, scaling_factor)
+    case zone_ventilation.designFlowRateCalculationMethod
+    when 'Flow/Area'
+      zone_ventilation.setFlowRateperZoneFloorArea(zone_ventilation.flowRateperZoneFloorArea.to_f * scaling_factor)
+    when 'Flow/Person'
+      zone_ventilation.setFlowRateperPerson(zone_ventilation.flowRateperPerson.to_f * scaling_factor)
+    when 'AirChanges/Hour'
+      zone_ventilation.setAirChangesperHour(zone_ventilation.airChangesperHour.to_f * scaling_factor)
+    when 'Flow/Zone'
+      zone_ventilation.setDesignFlowRate(zone_ventilation.designFlowRate.to_f * scaling_factor)
+    else
+      msg = "Unsupported ZoneVentilationDesignFlowRate calculation method '#{zone_ventilation.designFlowRateCalculationMethod}' for '#{zone_ventilation.nameString}'."
+      OpenStudio.logFree(OpenStudio::Error, 'openstudio.standards.Model', msg)
+      raise msg
+    end
+  end
+
+  def scale_zone_level_outdoor_airflow_rates(model, scaling_factor)
+    model.getThermalZones.sort.each do |zone|
+      zone.equipment.each do |zone_equipment|
+        if zone_equipment.to_ZoneHVACPackagedTerminalAirConditioner.is_initialized
+          zone_hvac = zone_equipment.to_ZoneHVACPackagedTerminalAirConditioner.get
+          cooling_value = _scaled_value(zone_hvac, :outdoorAirFlowRateDuringCoolingOperation, :autosizedCoolingOutdoorAirFlowRate, scaling_factor)
+          heating_value = _scaled_value(zone_hvac, :outdoorAirFlowRateDuringHeatingOperation, :autosizedHeatingOutdoorAirFlowRate, scaling_factor)
+          no_load_value = _scaled_value(zone_hvac, :outdoorAirFlowRateWhenNoCoolingorHeatingisNeeded, :autosizedNoLoadOutdoorAirFlowRate, scaling_factor)
+          zone_hvac.setOutdoorAirFlowRateDuringCoolingOperation(cooling_value) unless cooling_value.nil?
+          zone_hvac.setOutdoorAirFlowRateDuringHeatingOperation(heating_value) unless heating_value.nil?
+          zone_hvac.setOutdoorAirFlowRateWhenNoCoolingorHeatingisNeeded(no_load_value) unless no_load_value.nil?
+        elsif zone_equipment.to_ZoneHVACPackagedTerminalHeatPump.is_initialized
+          zone_hvac = zone_equipment.to_ZoneHVACPackagedTerminalHeatPump.get
+          cooling_value = _scaled_value(zone_hvac, :outdoorAirFlowRateDuringCoolingOperation, :autosizedCoolingOutdoorAirFlowRate, scaling_factor)
+          heating_value = _scaled_value(zone_hvac, :outdoorAirFlowRateDuringHeatingOperation, :autosizedHeatingOutdoorAirFlowRate, scaling_factor)
+          no_load_value = _scaled_value(zone_hvac, :outdoorAirFlowRateWhenNoCoolingorHeatingisNeeded, :autosizedNoLoadOutdoorAirFlowRate, scaling_factor)
+          zone_hvac.setOutdoorAirFlowRateDuringCoolingOperation(cooling_value) unless cooling_value.nil?
+          zone_hvac.setOutdoorAirFlowRateDuringHeatingOperation(heating_value) unless heating_value.nil?
+          zone_hvac.setOutdoorAirFlowRateWhenNoCoolingorHeatingisNeeded(no_load_value) unless no_load_value.nil?
+        elsif zone_equipment.to_ZoneHVACWaterToAirHeatPump.is_initialized
+          zone_hvac = zone_equipment.to_ZoneHVACWaterToAirHeatPump.get
+          cooling_value = _scaled_value(zone_hvac, :outdoorAirFlowRateDuringCoolingOperation, :autosizedCoolingOutdoorAirFlowRate, scaling_factor)
+          heating_value = _scaled_value(zone_hvac, :outdoorAirFlowRateDuringHeatingOperation, :autosizedHeatingOutdoorAirFlowRate, scaling_factor)
+          no_load_value = _scaled_value(zone_hvac, :outdoorAirFlowRateWhenNoCoolingorHeatingisNeeded, :autosizedNoLoadOutdoorAirFlowRate, scaling_factor)
+          zone_hvac.setOutdoorAirFlowRateDuringCoolingOperation(cooling_value) unless cooling_value.nil?
+          zone_hvac.setOutdoorAirFlowRateDuringHeatingOperation(heating_value) unless heating_value.nil?
+          zone_hvac.setOutdoorAirFlowRateWhenNoCoolingorHeatingisNeeded(no_load_value) unless no_load_value.nil?
+        elsif zone_equipment.to_ZoneHVACTerminalUnitVariableRefrigerantFlow.is_initialized
+          zone_hvac = zone_equipment.to_ZoneHVACTerminalUnitVariableRefrigerantFlow.get
+          cooling_value = _scaled_value(zone_hvac, :outdoorAirFlowRateDuringCoolingOperation, :autosizedCoolingOutdoorAirFlowRate, scaling_factor)
+          heating_value = _scaled_value(zone_hvac, :outdoorAirFlowRateDuringHeatingOperation, :autosizedHeatingOutdoorAirFlowRate, scaling_factor)
+          no_load_value = _scaled_value(zone_hvac, :outdoorAirFlowRateWhenNoCoolingorHeatingisNeeded, :autosizedNoLoadOutdoorAirFlowRate, scaling_factor)
+          zone_hvac.setOutdoorAirFlowRateDuringCoolingOperation(cooling_value) unless cooling_value.nil?
+          zone_hvac.setOutdoorAirFlowRateDuringHeatingOperation(heating_value) unless heating_value.nil?
+          zone_hvac.setOutdoorAirFlowRateWhenNoCoolingorHeatingisNeeded(no_load_value) unless no_load_value.nil?
+        elsif zone_equipment.to_ZoneHVACFourPipeFanCoil.is_initialized
+          zone_hvac = zone_equipment.to_ZoneHVACFourPipeFanCoil.get
+          max_oa_value = _scaled_value(zone_hvac, :maximumOutdoorAirFlowRate, :autosizedMaximumOutdoorAirFlowRate, scaling_factor)
+          zone_hvac.setMaximumOutdoorAirFlowRate(max_oa_value) unless max_oa_value.nil?
+        elsif zone_equipment.to_ZoneVentilationDesignFlowRate.is_initialized
+          scale_zone_ventilation_design_flow_rate(zone_equipment.to_ZoneVentilationDesignFlowRate.get, scaling_factor)
+        end
+      end
+    end
   end
 
   # get minimum outdoor airflow rate from Controller:OutdoorAir
   # adjust design outdoor airflow rate in Sizing:System
   # @param model [object]
   def consistent_outdoor_airflow_rate(model)
-
     model.getAirLoopHVACs.each do |air_loop|
-
       # Skip if no outdoor air system
       next if air_loop.airLoopHVACOutdoorAirSystem.empty?
 
@@ -1587,8 +1876,8 @@ class ACM179dASHRAE9012007
       end
 
       # force the above value to Sizing:System
-      OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.Model', "Forcing OA rate to Sizing:System based on Controller:OutdoorAir "\
-        " | old value = #{minimum_outdoor_airflow_rate_m_3_per_s_old} | new value = #{minimum_outdoor_airflow_rate_m_3_per_s}")
+      OpenStudio.logFree(OpenStudio::Info, 'openstudio.standards.Model', 'Forcing OA rate to Sizing:System based on Controller:OutdoorAir  ' \
+                                                                         "| old value = #{minimum_outdoor_airflow_rate_m_3_per_s_old} | new value = #{minimum_outdoor_airflow_rate_m_3_per_s}")
       sizing_system.setDesignOutdoorAirFlowRate(minimum_outdoor_airflow_rate_m_3_per_s)
     end
   end
@@ -1701,6 +1990,7 @@ class ACM179dASHRAE9012007
     end
 
     # mark unmarked zones
+    # rubocop:disable Style/CombinableLoops
     model.getThermalZones.each do |zone|
       unless zone.additionalProperties.hasFeature('airloop user specified DCV exception')
         zone.additionalProperties.setFeature('airloop user specified DCV exception', false)
@@ -1710,6 +2000,7 @@ class ACM179dASHRAE9012007
         zone.additionalProperties.setFeature('zone user specified DCV exception', false)
       end
     end
+    # rubocop:enable Style/CombinableLoops
   end
 
   # https://github.com/NREL/openstudio-standards/blob/master/lib/openstudio-standards/standards/ashrae_90_1_prm/ashrae_90_1_prm.Model.rb#L1286
@@ -1762,10 +2053,8 @@ class ACM179dASHRAE9012007
          (!thermal_zone.additionalProperties.getFeatureAsBoolean('zone dcv required by 901').get ||
            !thermal_zone.additionalProperties.getFeatureAsBoolean('airloop dcv required by 901').get)
         OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.Model', "For thermal zone #{thermal_zone.name}, ASHRAE 90.1 2019 6.4.3.8 does NOT require this zone to have demand control ventilation, but it was implemented in the user model, Appendix G baseline generation will continue!")
-        if thermal_zone.additionalProperties.hasFeature('apxg no need to have DCV')
-          if !thermal_zone.additionalProperties.getFeatureAsBoolean('apxg no need to have DCV').get
-            OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.Model', "Moreover, for thermal zone #{thermal_zone.name}, Appendix G baseline model will have DCV based on ASHRAE 90.1 2019 G3.1.2.5")
-          end
+        if thermal_zone.additionalProperties.hasFeature('apxg no need to have DCV') && !thermal_zone.additionalProperties.getFeatureAsBoolean('apxg no need to have DCV').get
+          OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.Model', "Moreover, for thermal zone #{thermal_zone.name}, Appendix G baseline model will have DCV based on ASHRAE 90.1 2019 G3.1.2.5")
         end
       end
       if thermal_zone.additionalProperties.getFeatureAsBoolean('zone dcv required by 901').get &&
@@ -1791,11 +2080,11 @@ class ACM179dASHRAE9012007
         return false
       end
       # oa_flow_m3_per_s can be false if the sizing run failed or sql not avail
-      if oa_flow_m3_per_s != false
-        oa_flow_cfm = OpenStudio.convert(oa_flow_m3_per_s, 'm^3/s', 'cfm').get
-      else
+      if oa_flow_m3_per_s == false
         OpenStudio.logFree(OpenStudio::Warn, 'openstudio.standards.AirLoopHVAC', "For #{air_loop_hvac.name}, DCV not applicable because oa_flow_m3_per_s is FALSE.")
         return false
+      else
+        oa_flow_cfm = OpenStudio.convert(oa_flow_m3_per_s, 'm^3/s', 'cfm').get
       end
       if oa_flow_cfm <= 3000
         air_loop_hvac.thermalZones.each do |thermal_zone|
@@ -2023,10 +2312,10 @@ class ACM179dASHRAE9012007
       next unless fan.thermalZone.is_initialized
 
       zone = fan.thermalZone.get
-      next unless zone.spaces.any? { |s|
+      next unless zone.spaces.any? do |s|
         s.spaceType.is_initialized && s.spaceType.get.standardsSpaceType.is_initialized &&
-          ACM_EXHAUST_SPACE_TYPES.include?(s.spaceType.get.standardsSpaceType.get)
-      }
+        ACM_EXHAUST_SPACE_TYPES.include?(s.spaceType.get.standardsSpaceType.get)
+      end
 
       fan.setAvailabilitySchedule(acm_fan_sch)
       fan.setFlowFractionSchedule(acm_fan_sch)
@@ -2071,5 +2360,5 @@ class ACM179dASHRAE9012007
 
     zone_exhaust_fans
   end
-
 end
+# rubocop:enable Metrics/ClassLength

--- a/test/90_1_general/test_179d.rb
+++ b/test/90_1_general/test_179d.rb
@@ -303,6 +303,15 @@ class ACM179dASHRAE9012007Test < Minitest::Test
     building = model.getBuilding
     building.setStandardsBuildingType('PrimarySchool')
 
+    vent_zone = OpenStudio::Model::ThermalZone.new(model)
+    vent_space = OpenStudio::Model::Space.new(model)
+    vent_space.setThermalZone(vent_zone)
+    ventilation = OpenStudio::Model::ZoneVentilationDesignFlowRate.new(model)
+    ventilation.setName('Warehouse Test Ventilation')
+    ventilation.setSchedule(model.alwaysOnDiscreteSchedule)
+    ventilation.setDesignFlowRate(0.01)
+    ventilation.addToThermalZone(vent_zone)
+
     _airloophvac = OpenStudio::Model::AirLoopHVAC.new(model)
 
     _baseboardconvectiveelectric = OpenStudio::Model::ZoneHVACBaseboardConvectiveElectric.new(model)
@@ -412,6 +421,8 @@ class ACM179dASHRAE9012007Test < Minitest::Test
         end
       end
     end
+
+    assert_equal('SchoolPrimary_HVAC_Sch', ventilation.schedule.nameString)
   end
 
   def test_space_type_apply_internal_loads_also_sets_people_fraction_sensible

--- a/test/90_1_prm/test_prm_baseline_bldg_179d.rb
+++ b/test/90_1_prm/test_prm_baseline_bldg_179d.rb
@@ -61,5 +61,27 @@ class ACM179dASHRAE9012007BaselineBuildingTest < Minitest::Test
       assert_in_delta(lighting_per_area_si, base_lpd_si, 0.001, "LPD failure for #{base_sp.nameString}")
     end
 
+    ventilation_zvs = base_model.getZoneVentilationDesignFlowRates.select { |zv| zv.nameString.end_with?(' Ventilation') }
+    cooling_exhaust_zvs = base_model.getZoneVentilationDesignFlowRates.select { |zv| zv.nameString.end_with?(' Cooling Exhaust') }
+    cooling_makeup_zvs = base_model.getZoneVentilationDesignFlowRates.select { |zv| zv.nameString.end_with?(' Cooling Makeup Air Intake') }
+
+    assert_operator(ventilation_zvs.size, :>, 0)
+    assert_operator(cooling_exhaust_zvs.size, :>, 0)
+    assert_operator(cooling_makeup_zvs.size, :>, 0)
+
+    ventilation_zvs.each do |zv|
+      refute_equal(base_model.alwaysOnDiscreteSchedule, zv.schedule, "#{zv.nameString} should run on ACM occupied schedule")
+    end
+
+    cooling_exhaust_zvs.each do |zv|
+      assert(zv.thermalZone.is_initialized)
+      assert(zv.thermalZone.get.spaces.all? { |space| space.exteriorArea <= 0.001 }, "#{zv.nameString} should be on interior zones only")
+    end
+
+    cooling_makeup_zvs.each do |zv|
+      assert(zv.thermalZone.is_initialized)
+      assert(zv.thermalZone.get.spaces.any? { |space| space.exteriorArea > 0.001 }, "#{zv.nameString} should be on exterior-connected zones only")
+    end
+
   end
 end


### PR DESCRIPTION
## Summary

Companion port of the 179D warehouse non-mechanical cooling behavior from **NREL/openstudio-bem-to-surrogate-gem#418** into `openstudio-standards`, following the same selective companion-port pattern used in prior ports (eg #54 for BEM #430).

## Ported scope (equivalent surfaces only)

1. `lib/openstudio-standards/standards/.../179d_ashrae_90_1_2007.Model.rb`
   - synced ACM HVAC occupied schedule onto pre-existing `" Ventilation"` ZoneVentilationDesignFlowRate objects
   - ported expanded heated-only zone ventilation routine with non-mechanical cooling support (`add_cooling_exhaust`) including:
     - interior/exterior zone split
     - cooling exhaust vs cooling makeup intake objects
     - mixing and mixing makeup intake handling
     - helper methods for exterior/source-zone resolution and cooling gate setup
   - added `model_add_ddy_only_infiltration_for_heated_only_zones` helper for post-infiltration convergence fallback

2. `lib/openstudio-standards/create_typical/create_typical.rb`
   - added 179D Warehouse post-infiltration DDY-only fallback call for heated-only zones marked by `" Ventilation"` ZVs
   - preserves sequencing where pre-SR1 call uses `ensure_ddy_infiltration: false`

3. Tests
   - `test/90_1_general/test_179d.rb`: assert ACM schedule propagation to an existing `" Ventilation"` ZV
   - `test/90_1_prm/test_prm_baseline_bldg_179d.rb`: assert warehouse baseline emits ventilation/cooling objects with interior-vs-exterior placement expectations

## Intentionally not ported from source PR #418

The source PR includes many measure-layer and repo-specific changes that do not have direct equivalents in this repo (eg measure wrappers, reporting measure files, measure XML/template updates, and unrelated tooling/config files). Those were intentionally omitted to keep this companion scoped to equivalent standards/create_typical behavior surfaces.

## Notes

- Source PR: https://github.com/NREL/openstudio-bem-to-surrogate-gem/pull/418
- Companion-port precedent: https://github.com/jmarrec/openstudio-standards/pull/54
