### PR TITLE
Remove year-less '179D ACM' standard alias

### DIFF
--- a/lib/openstudio-standards/standards/acm/acm_2019/179d_acm_2019/179d_acm_2019.rb
+++ b/lib/openstudio-standards/standards/acm/acm_2019/179d_acm_2019/179d_acm_2019.rb
@@ -1,6 +1,5 @@
 class ACM179dACM2019 < Standard
   register_standard '179D ACM 2019'
-  register_standard '179D ACM'
   attr_reader :template
 
   ACM_TEMPLATE = '179d-ACM-2019'.freeze


### PR DESCRIPTION
## Why do we need this PR
The 179D ACM 2019 standard registered two names: the canonical `'179D ACM 2019'` and a bare year-less alias `'179D ACM'`. Nothing builds the bare alias, so it is dead surface that can drift as more ACM year variants appear.

## Core change explanation
Drop the `register_standard '179D ACM'` line. The standard is still registered and built under its canonical `'179D ACM 2019'` name.

## Which files are affected
- `lib/openstudio-standards/standards/acm/acm_2019/179d_acm_2019/179d_acm_2019.rb`

## What kind of tests are done
- Static check: searched the `179D_310` branch for any `Standard.build('179D ACM')` (year-less) usage — none exists, so no call site or test depends on the alias.